### PR TITLE
Hightlight *.sbt files as scala code

### DIFF
--- a/data/syntax/scala.xml
+++ b/data/syntax/scala.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
 <language name="Scala" version="2" kateversion="2.3" section="Sources"
-          extensions="*.scala" mimetype="text/x-scala" license="LGPL"
+          extensions="*.scala;*.sbt" mimetype="text/x-scala" license="LGPL"
           author="Stephane Micheloud (stephane.micheloud@epfl.ch)">
 <!--
 First version added to reository was 1.0 downloaded from


### PR DESCRIPTION
Configuration files of sbt (Scala/Simple build tool) are written in scala, so they should be highlighted as such.