### PR TITLE
Adding file extensions to PHP syntax

### DIFF
--- a/data/syntax/php.xml
+++ b/data/syntax/php.xml
@@ -2,6 +2,9 @@
 <!--
 
 Changes:
+[ Version 1.48 (2017-04-24) ]
+- added file extensions
+
 [ Version 1.47 (2015-03-24) ]
 - added support for binary integer literals
 

--- a/data/syntax/php.xml
+++ b/data/syntax/php.xml
@@ -70,7 +70,7 @@ Changes:
   <!ENTITY types "int|integer|bool|boolean|float|double|real|string|array|object">
 ]>
 
-<language name="PHP/PHP" indenter="cstyle" version="2" kateversion="3.4" section="Scripts" extensions="" priority="5" mimetype="" hidden="true">
+<language name="PHP/PHP" indenter="cstyle" version="2" kateversion="3.4" section="Scripts" extensions="*.php;*.phtml" priority="5" mimetype="" hidden="true">
   <highlighting>
     <list name="control structures">
       <item>as</item>


### PR DESCRIPTION
For some reason that is unknown to me the PHP syntax file lacks the known file extensions list.