### PR TITLE
Add PHP 7 information

### DIFF
--- a/data/syntax/php.xml
+++ b/data/syntax/php.xml
@@ -150,6 +150,23 @@ Changes:
       <item> var </item>
       <item> xor </item>
       <item> yield </item>
+
+      <!-- PHP 7.0 -->
+      <item> bool </item>
+      <item> false </item>
+      <item> float </item>
+      <item> int </item>
+      <item> mixed </item>
+      <item> null </item>
+      <item> numeric </item>
+      <item> object </item>
+      <item> resource </item>
+      <item> string </item>
+      <item> true </item>
+
+      <!-- PHP 7.1 -->
+      <item> iterable </item>
+      <item> void </item>
     </list>
 
     <!-- https://secure.php.net/manual/en/reserved.keywords.php -->
@@ -212,6 +229,16 @@ Changes:
       <item> E_ALL </item>
       <item> E_STRICT </item>
       <item> __COMPILER_HALT_OFFSET__ </item>
+
+      <!-- PHP 7.0 (Core Pre-Defined Constants) -->
+      <item> PHP_INT_MIN </item>
+
+      <!-- PHP 7.2 (Core Pre-Defined Constants) -->
+      <item> PHP_OS_FAMILY </item>
+      <item> PHP_FLOAT_DIG </item>
+      <item> PHP_FLOAT_EPSILON </item>
+      <item> PHP_FLOAT_MIN </item>
+      <item> PHP_FLOAT_MAX </item>
 
       <!-- Extensions -->
       <item> ABDAY_1 </item>

--- a/data/syntax/php.xml
+++ b/data/syntax/php.xml
@@ -72,8 +72,9 @@ Changes:
 
 <language name="PHP/PHP" indenter="cstyle" version="3" kateversion="3.4" section="Scripts" extensions="" priority="5" mimetype="" hidden="true">
   <highlighting>
+    <!-- https://secure.php.net/manual/en/reserved.keywords.php -->
     <list name="control structures">
-      <item>as</item>
+      <!-- PHP 5.6 -->
       <item>case</item>
       <item>default</item>
       <item>if</item>
@@ -86,65 +87,133 @@ Changes:
       <item>break</item>
       <item>continue</item>
       <item>switch</item>
-      <item>declare</item>
       <item>return</item>
       <item>require</item>
       <item>include</item>
-      <item>require_once</item>
-      <item>include_once</item>
       <item>endif</item>
       <item>endwhile</item>
       <item>endfor</item>
       <item>endforeach</item>
       <item>endswitch</item>
     </list>
+
+    <!-- https://secure.php.net/manual/en/reserved.keywords.php -->
+    <!-- https://secure.php.net/manual/en/reserved.other-reserved-words.php -->
     <list name="keywords">
+      <!-- PHP 5.6 -->
+      <item> __halt_compiler </item>
       <item> abstract </item>
+      <item> and </item>
+      <item> array </item>
+      <item> as </item>
       <item> callable </item>
       <item> catch </item>
       <item> class </item>
       <item> clone </item>
       <item> const </item>
-      <item> exception </item>
+      <item> declare </item>
+      <item> die </item>
+      <item> echo </item>
+      <item> empty </item>
+      <item> enddeclare </item>
+      <item> eval </item>
+      <item> exit </item>
       <item> extends </item>
       <item> final </item>
       <item> finally </item>
       <item> function </item>
       <item> global </item>
+      <item> goto </item>
       <item> implements </item>
+      <item> include </item>
+      <item> include_once </item>
       <item> instanceof </item>
       <item> insteadof </item>
       <item> interface </item>
+      <item> isset </item>
+      <item> list </item>
+      <item> namespace </item>
       <item> new </item>
-      <item> self </item>
-      <item> static </item>
-      <item> parent </item>
+      <item> or </item>
+      <item> print </item>
       <item> private </item>
       <item> protected </item>
       <item> public </item>
+      <item> require </item>
+      <item> require_once </item>
+      <item> static </item>
       <item> throw </item>
-      <item> try </item>
       <item> trait </item>
-      <item> and </item>
-      <item> or </item>
-      <item> xor </item>
-      <item> var </item>
-      <item> namespace </item>
+      <item> try </item>
+      <item> unset </item>
       <item> use </item>
+      <item> var </item>
+      <item> xor </item>
       <item> yield </item>
     </list>
-      <!-- magic constants, see http://php.net/manual/en/language.constants.predefined.php -->
+
+    <!-- https://secure.php.net/manual/en/reserved.keywords.php -->
+    <!-- https://secure.php.net/manual/en/reserved.constants.php -->
     <list name="constants">
-      <item> __LINE__ </item>
-      <item> __FILE__ </item>
-      <item> __DIR__ </item>
-      <item> __FUNCTION__ </item>
+      <!-- PHP 5.6 (Compile-Time Constants) -->
       <item> __CLASS__ </item>
+      <item> __DIR__ </item>
+      <item> __FILE__ </item>
+      <item> __FUNCTION__ </item>
+      <item> __LINE__ </item>
       <item> __METHOD__ </item>
       <item> __NAMESPACE__ </item>
       <item> __TRAIT__ </item>
+
+      <!-- PHP 5.6 (Core Pre-Defined Constants ) -->
+      <item> PHP_VERSION </item>
+      <item> PHP_MAJOR_VERSION </item>
+      <item> PHP_MINOR_VERSION </item>
+      <item> PHP_RELEASE_VERSION </item>
+      <item> PHP_VERSION_ID </item>
+      <item> PHP_EXTRA_VERSION </item>
+      <item> PHP_ZTS </item>
+      <item> PHP_DEBUG </item>
+      <item> PHP_MAXPATHLEN </item>
+      <item> PHP_OS </item>
+      <item> PHP_SAPI </item>
+      <item> PHP_EOL </item>
+      <item> PHP_INT_MAX </item>
+      <item> PHP_INT_SIZE </item>
+      <item> DEFAULT_INCLUDE_PATH </item>
+      <item> PEAR_INSTALL_DIR </item>
+      <item> PEAR_EXTENSION_DIR </item>
+      <item> PHP_EXTENSION_DIR </item>
+      <item> PHP_PREFIX </item>
+      <item> PHP_BINDIR </item>
+      <item> PHP_BINARY </item>
+      <item> PHP_MANDIR </item>
+      <item> PHP_LIBDIR </item>
+      <item> PHP_DATADIR </item>
+      <item> PHP_SYSCONFDIR </item>
+      <item> PHP_LOCALSTATEDIR </item>
+      <item> PHP_CONFIG_FILE_PATH </item>
+      <item> PHP_CONFIG_FILE_SCAN_DIR </item>
+      <item> PHP_SHLIB_SUFFIX  </item>
+      <item> PHP_FD_SETSIZE </item>
+      <item> E_ERROR </item>
+      <item> E_WARNING </item>
+      <item> E_PARSE </item>
+      <item> E_NOTICE </item>
+      <item> E_CORE_ERROR </item>
+      <item> E_CORE_WARNING </item>
+      <item> E_COMPILE_ERROR </item>
+      <item> E_COMPILE_WARNING </item>
+      <item> E_USER_ERROR </item>
+      <item> E_USER_WARNING </item>
+      <item> E_USER_NOTICE </item>
+      <item> E_DEPRECATED </item>
+      <item> E_USER_DEPRECATED </item>
+      <item> E_ALL </item>
+      <item> E_STRICT </item>
       <item> __COMPILER_HALT_OFFSET__ </item>
 
+      <!-- Extensions -->
       <item> ABDAY_1 </item>
       <item> ABDAY_2 </item>
       <item> ABDAY_3 </item>
@@ -474,7 +543,6 @@ Changes:
       <item> DBX_RESULT_UNBUFFERED </item>
       <item> DBX_SQLITE </item>
       <item> DBX_SYBASECT </item>
-      <item> DEFAULT_INCLUDE_PATH </item>
       <item> DIRECTORY_SEPARATOR </item>
       <item> DNS_A </item>
       <item> DNS_AAAA </item>
@@ -530,23 +598,6 @@ Changes:
       <item> EXTR_PREFIX_SAME </item>
       <item> EXTR_REFS </item>
       <item> EXTR_SKIP </item>
-      <item> E_ALL </item>
-      <item> E_COMPILE_ERROR </item>
-      <item> E_COMPILE_WARNING </item>
-      <item> E_CORE_ERROR </item>
-      <item> E_CORE_WARNING </item>
-      <item> E_DEPRECATED </item>
-      <item> E_ERROR </item>
-      <item> E_NOTICE </item>
-      <item> E_PARSE </item>
-      <item> E_RECOVERABLE_ERROR </item>
-      <item> E_STRICT </item>
-      <item> E_USER_DEPRECATED </item>
-      <item> E_USER_ERROR </item>
-      <item> E_USER_NOTICE </item>
-      <item> E_USER_WARNING </item>
-      <item> E_WARNING </item>
-      <item> FALSE </item>
       <item> FAMAcknowledge </item>
       <item> FAMChanged </item>
       <item> FAMCreated </item>
@@ -1177,8 +1228,6 @@ Changes:
       <item> PATHINFO_EXTENSION </item>
       <item> PATHINFO_FILENAME </item>
       <item> PATH_SEPARATOR </item>
-      <item> PEAR_EXTENSION_DIR </item>
-      <item> PEAR_INSTALL_DIR </item>
       <item> PGSQL_ASSOC </item>
       <item> PGSQL_BAD_RESPONSE </item>
       <item> PGSQL_BOTH </item>
@@ -1206,23 +1255,10 @@ Changes:
       <item> PGSQL_STATUS_STRING </item>
       <item> PGSQL_TUPLES_OK </item>
       <item> PHP_BINARY_READ </item>
-      <item> PHP_BINDIR </item>
-      <item> PHP_CONFIG_FILE_PATH </item>
-      <item> PHP_CONFIG_FILE_SCAN_DIR </item>
-      <item> PHP_DATADIR </item>
-      <item> PHP_EOL </item>
-      <item> PHP_EXTENSION_DIR </item>
-      <item> PHP_LIBDIR </item>
-      <item> PHP_LOCALSTATEDIR </item>
       <item> PHP_NORMAL_READ </item>
-      <item> PHP_OS </item>
       <item> PHP_OUTPUT_HANDLER_CONT </item>
       <item> PHP_OUTPUT_HANDLER_END </item>
       <item> PHP_OUTPUT_HANDLER_START </item>
-      <item> PHP_PREFIX </item>
-      <item> PHP_SAPI </item>
-      <item> PHP_SHLIB_SUFFIX </item>
-      <item> PHP_SYSCONFDIR </item>
       <item> PHP_URL_FRAGMENT </item>
       <item> PHP_URL_HOST </item>
       <item> PHP_URL_PASS </item>
@@ -1231,7 +1267,6 @@ Changes:
       <item> PHP_URL_QUERY </item>
       <item> PHP_URL_SCHEME </item>
       <item> PHP_URL_USER </item>
-      <item> PHP_VERSION </item>
       <item> PKCS7_BINARY </item>
       <item> PKCS7_DETACHED </item>
       <item> PKCS7_NOATTR </item>
@@ -1646,7 +1681,6 @@ Changes:
       <item> S_IXOTH </item>
       <item> S_IXUSR </item>
       <item> THOUSEP </item>
-      <item> TRUE </item>
       <item> TYPEAPPLICATION </item>
       <item> TYPEAUDIO </item>
       <item> TYPEIMAGE </item>
@@ -1916,18 +1950,19 @@ Changes:
       <item> YPERR_YPERR </item>
       <item> YPERR_YPSERV </item>
       <item> ZEND_THREAD_SAFE </item>
-      <item> false </item>
-      <item> null </item>
-      <item> true </item>
     </list>
+
+    <!-- https://secure.php.net/manual/en/language.oop5.magic.php -->
     <list name="special_methods">
       <item> __autoload </item>
       <item> __call </item>
+      <item> __callStatic </item>
       <item> __clone </item>
       <item> __construct </item>
+      <item> __debugInfo </item>
       <item> __destruct </item>
       <item> __get </item>
-      <item> __halt_compiler </item>
+      <item> __invoke </item>
       <item> __isset </item>
       <item> __set </item>
       <item> __set_state </item>
@@ -1936,6 +1971,7 @@ Changes:
       <item> __unset </item>
       <item> __wakeup </item>
     </list>
+
     <list name="functions">
       <item> _ </item>
       <item> abs </item>


### PR DESCRIPTION
* This pull requests cleans up PHP 5 information and adds information for PHP 7
* It only touches control structures, keywords, and constants
* It does not touch functions, for instance

Personally, I do think that highlighting all functions of all extensions (that are documented on php.net) is all that valuable. I did not remove the existing information, though. I did not update it, either.