### PR TITLE
Support clojure's "@" macro with brackets

### DIFF
--- a/data/syntax/clojure.xml
+++ b/data/syntax/clojure.xml
@@ -708,6 +708,7 @@
         <Detect2Chars attribute="Brackets1" context="Level1" char="'" char1="("/>
         <Detect2Chars attribute="Brackets1" context="Level1" char="`" char1="("/>
         <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets1" context="Level1" char="@" char1="("/>
         <IncludeRules context="Default" />
       </context>
       <context name="Default" attribute="Normal" lineEndContext="#stay">
@@ -790,6 +791,7 @@
         <Detect2Chars attribute="Brackets2" context="Level2" char="'" char1="("/>
         <Detect2Chars attribute="Brackets2" context="Level2" char="`" char1="("/>
         <Detect2Chars attribute="Brackets2" context="Level2" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets2" context="Level2" char="@" char1="("/>
         <DetectChar attribute="Brackets1" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>
@@ -798,6 +800,7 @@
         <Detect2Chars attribute="Brackets3" context="Level3" char="'" char1="("/>
         <Detect2Chars attribute="Brackets3" context="Level3" char="`" char1="("/>
         <Detect2Chars attribute="Brackets3" context="Level3" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets3" context="Level3" char="@" char1="("/>
         <DetectChar attribute="Brackets2" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>
@@ -806,6 +809,7 @@
         <Detect2Chars attribute="Brackets4" context="Level4" char="'" char1="("/>
         <Detect2Chars attribute="Brackets4" context="Level4" char="`" char1="("/>
         <Detect2Chars attribute="Brackets4" context="Level4" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets4" context="Level4" char="@" char1="("/>
         <DetectChar attribute="Brackets3" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>
@@ -814,6 +818,7 @@
         <Detect2Chars attribute="Brackets5" context="Level5" char="'" char1="("/>
         <Detect2Chars attribute="Brackets5" context="Level5" char="`" char1="("/>
         <Detect2Chars attribute="Brackets5" context="Level5" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets5" context="Level5" char="@" char1="("/>
         <DetectChar attribute="Brackets4" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>
@@ -822,6 +827,7 @@
         <Detect2Chars attribute="Brackets6" context="Level6" char="'" char1="("/>
         <Detect2Chars attribute="Brackets6" context="Level6" char="`" char1="("/>
         <Detect2Chars attribute="Brackets6" context="Level6" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets6" context="Level6" char="@" char1="("/>
         <DetectChar attribute="Brackets5" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>
@@ -830,6 +836,7 @@
         <Detect2Chars attribute="Brackets1" context="Level1" char="'" char1="("/>
         <Detect2Chars attribute="Brackets1" context="Level1" char="`" char1="("/>
         <Detect2Chars attribute="Brackets1" context="Level1" char="#" char1="("/>
+        <Detect2Chars attribute="Brackets1" context="Level1" char="@" char1="("/>
         <DetectChar attribute="Brackets6" context="#pop" char=")" />
         <IncludeRules context="Default" />
       </context>


### PR DESCRIPTION
This change will fix clojure's syntax highlighting like the following code:
```clojure
(defn- getfield [this k]
  (@(.state this) k))
```