### PR TITLE
Add support for the Stan modeling language

### DIFF
--- a/autotests/folding/highlight.stan.fold
+++ b/autotests/folding/highlight.stan.fold
@@ -1,0 +1,380 @@
+<beginfold id='1'>/*</beginfold id='1'> Stan Highlighting Example
+
+  This file contains a syntatically correct but nonsensical Stan program that
+  includes almost every feature of the language needed to validate syntax
+  highlighters. It will compile (as of Stan 2.17.1), but it does nothing
+  useful.
+
+  Author: Jeffrey Arnold <jeffrey.anold@gmail.com>
+  Copyright: Jeffrey Arnold (2018)
+  License: MIT
+
+<endfold id='1'>*/</endfold id='1'>
+// line comment
+# deprecated line comment
+functions <beginfold id='2'>{</beginfold id='2'>
+  #include stuff.stan
+  #include "morestuff.stan"
+  #include 'moststuff.stan'
+  #include <evenmorestuff.stan>
+
+  // declarations
+  void oof(real x);
+
+  // definitions
+  // return types
+  void oof(real x) <beginfold id='2'>{</beginfold id='2'>
+    print("print ", x);
+  <endfold id='2'>}</endfold id='2'>
+  <beginfold id='1'>/*</beginfold id='1'>
+    @param x A number
+    @return x + 1
+  <endfold id='1'>*/</endfold id='1'>
+  real foo(real x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  int bar(int x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  vector baz(vector x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  row_vector qux(row_vector x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  matrix quux(matrix x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  // numbers of arguments
+  void corge() <beginfold id='2'>{</beginfold id='2'>
+    print("no parameters");
+  <endfold id='2'>}</endfold id='2'>
+  void grault(int a, real b, vector c, row_vector d, matrix f) <beginfold id='2'>{</beginfold id='2'>
+    print("many parameters");
+  <endfold id='2'>}</endfold id='2'>
+  void garply(real a, real[] b, real[,] c, real[,,] d) <beginfold id='2'>{</beginfold id='2'>
+    print("array arguments");
+  <endfold id='2'>}</endfold id='2'>
+  // array return types
+  int[] waldo(int[] x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  int[,] fred(int[,] x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  int[,,] plough(int[,,] x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  // data only function argument
+  real plugh(data real x) <beginfold id='2'>{</beginfold id='2'>
+    return x;
+  <endfold id='2'>}</endfold id='2'>
+  // ode function
+  real[] ode_func(real a, real[] b, real[] c, real[] d, int[] e) <beginfold id='2'>{</beginfold id='2'>
+    return b;
+  <endfold id='2'>}</endfold id='2'>
+<endfold id='2'>}</endfold id='2'>
+data <beginfold id='2'>{</beginfold id='2'>
+  // non-int variable types
+  int x_int;
+  real x_real;
+  real y_real;
+  vector[1] x_vector;
+  ordered[1] x_ordered;
+  positive_ordered[1] x_positive_ordered;
+  simplex[1] x_simplex;
+  unit_vector[1] x_unit_vector;
+  row_vector[1] x_row_vector;
+  matrix[1, 1] x_matrix;
+  cholesky_factor_corr[2] x_cholesky_factor_corr;
+  cholesky_factor_cov[2] x_cholesky_factor_cov;
+  cholesky_factor_cov[2, 3] x_cholesky_factor_cov_2;
+  corr_matrix[2] x_corr_matrix;
+  cov_matrix[2] x_cov_matrix;
+
+  // range constraints
+  real<lower = 0., upper = 1.> alpha;
+  real<lower = 0.> bravo;
+  real<upper = 1.> charlie;
+
+  // arrays
+  int echo[1];
+  int foxtrot[1, 1];
+  int golf[1, 1, 1];
+
+  // identifier with all valid letters
+  real abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789;
+
+  // hard pattern
+  real<lower = (bravo < charlie), upper = (bravo > charlie)> ranger;
+
+  // identifier patterns
+  real a;
+  real a3;
+  real a_3;
+  real Sigma;
+  real my_cpp_style_variable;
+  real myCamelCaseVariable;
+  real abcdefghijklmnojk;
+  // names beginning with keywords
+  real iffffff;
+  real whilest;
+  // name ending with truncation
+  real fooT;
+<endfold id='2'>}</endfold id='2'>
+transformed data <beginfold id='2'>{</beginfold id='2'>
+  // declaration and assignment
+  int india = 1;
+  real romeo = 1.0;
+  row_vector[2] victor = [1, 2];
+  matrix[2, 2] mike = [[1, 2], [3, 4]];
+  real sierra[2] = <beginfold id='2'>{</beginfold id='2'>1., 2.<endfold id='2'>}</endfold id='2'>;
+<endfold id='2'>}</endfold id='2'>
+parameters <beginfold id='2'>{</beginfold id='2'>
+  real hotel;
+<endfold id='2'>}</endfold id='2'>
+transformed parameters <beginfold id='2'>{</beginfold id='2'>
+  real juliette;
+  juliette = hotel * 2.;
+<endfold id='2'>}</endfold id='2'>
+model <beginfold id='2'>{</beginfold id='2'>
+  real x;
+  int k;
+  vector[2] y = [1., 1.]';
+  matrix[2, 2] A = [[1., 1.], [1., 1.]];
+  real odeout[2, 2];
+  real algout[2, 2];
+
+  // if else statements
+  if (x_real < 0) x = 0.;
+
+  if (x_real < 0) <beginfold id='2'>{</beginfold id='2'>
+    x = 0.;
+  <endfold id='2'>}</endfold id='2'>
+
+  if (x_real < 0) x = 0.;
+  else x = 1.;
+
+  if (x_real < 0) <beginfold id='2'>{</beginfold id='2'>
+    x = 0.;
+  <endfold id='2'>}</endfold id='2'> else <beginfold id='2'>{</beginfold id='2'>
+    x = 1.;
+  <endfold id='2'>}</endfold id='2'>
+
+  if (x_real < 0) x = 0.;
+  else if (x_real > 1) x = 1.;
+  else x = 0.5;
+
+  if (x_real < 0) <beginfold id='2'>{</beginfold id='2'>
+    x = 0.;
+  <endfold id='2'>}</endfold id='2'> else if (x_real > 1) <beginfold id='2'>{</beginfold id='2'>
+    x = 1.;
+  <endfold id='2'>}</endfold id='2'> else <beginfold id='2'>{</beginfold id='2'>
+    x = 0.5;
+  <endfold id='2'>}</endfold id='2'>
+
+  // for loops
+  for (i in 1:5) <beginfold id='2'>{</beginfold id='2'>
+    print("i = ", i);
+  <endfold id='2'>}</endfold id='2'>
+  // for (j in echo) {
+  //   print("j = ", j);
+  // }
+  // while loop
+  while (1) <beginfold id='2'>{</beginfold id='2'>
+    break;
+    continue;
+  <endfold id='2'>}</endfold id='2'>
+
+  // reject statement
+  reject("reject statment ", x_real);
+
+  // print statement
+  print("print statement ", x_real);
+  print("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_~@#$%^&*`'-+={}[].,;: ");
+
+  // increment log probability statements;
+  target += 1.;
+
+  // valid integer literals
+  k = 0;
+  k = 1;
+  k = -1;
+  k = 256;
+  k = -127098;
+  k = 007;
+
+  // valid real literals
+  x = 0.0;
+  x = 1.0;
+  x = 3.14;
+  x = 003.14;
+  x = -217.9387;
+  x = 0.123;
+  x = .123;
+  x = 1.;
+  x = -0.123;
+  x = -.123;
+  x = -1.;
+  x = 12e34;
+  x = 12E34;
+  x = 12.e34;
+  x = 12.E34;
+  x = 12.0e34;
+  x = 12.0E34;
+  x = .1e34;
+  x = .1E34;
+  x = -12e34;
+  x = -12E34;
+  x = -12.e34;
+  x = -12.E34;
+  x = -12.0e34;
+  x = -12.0E34;
+  x = -.1e34;
+  x = -.1E34;
+  x = 12e-34;
+  x = 12E-34;
+  x = 12.e-34;
+  x = 12.E-34;
+  x = 12.0e-34;
+  x = 12.0E-34;
+  x = .1e-34;
+  x = .1E-34;
+  x = -12e-34;
+  x = -12E-34;
+  x = -12.e-34;
+  x = -12.E-34;
+  x = -12.0e-34;
+  x = -12.0E-34;
+  x = -.1e-34;
+  x = -.1E-34;
+  x = 12e+34;
+  x = 12E+34;
+  x = 12.e+34;
+  x = 12.E+34;
+  x = 12.0e+34;
+  x = 12.0E+34;
+  x = .1e+34;
+  x = .1E+34;
+  x = -12e+34;
+  x = -12E+34;
+  x = -12.e+34;
+  x = -12.E+34;
+  x = -12.0e+34;
+  x = -12.0E+34;
+  x = -.1e+34;
+  x = -.1E+34;
+
+  // assignment statements
+  x = 1;
+  x += 1.;
+  x -= 1.;
+  x *= 1.;
+  x /= 1.;
+  y .*= x_vector;
+  y ./= x_vector;
+
+  // operators
+  x = x_real && 1;
+  x = x_real || 1;
+  x = x_real < 1.;
+  x = x_real <= 1.;
+  x = x_real > 1.;
+  x = x_real >= 1.;
+  x = x_real + 1.;
+  x = x_real - 1.;
+  x = x_real * 1.;
+  x = x_real / 1.;
+  x = x_real ^ 2.;
+  x = x_real % 2;
+  x = !x_real;
+  x = +x_real;
+  x = -x_real;
+  x = x_int ? x_real : 0.;
+
+  y = x_row_vector';
+  y = x_matrix \ x_vector;
+  y = x_vector .* x_vector;
+  y = x_vector ./ x_vector;
+
+  // parenthized expression
+  x = (x_real + x_real);
+
+  // block statement
+  <beginfold id='2'>{</beginfold id='2'>
+    real z;
+    z = 1.;
+  <endfold id='2'>}</endfold id='2'>
+
+  // built-in functions
+  x = log(1.);
+  x = exp(1.);
+
+  // non-built-in function
+  x = foo(1.);
+
+  // constants and nullary functions
+  x = machine_precision();
+  x = pi();
+  x = e();
+  x = sqrt2();
+  x = log2();
+  x = log10();
+  // special values
+  x = not_a_number();
+  x = positive_infinity();
+  x = negative_infinity();
+  x = machine_precision();
+  // log probability
+  x = target();
+
+  // sampling statement
+  x_real ~ normal(0., 1.);
+
+  // truncation
+  x_real ~ normal(0., 1.) T[-1., 1.];
+  x_real ~ normal(0., 1.) T[, 1.];
+  x_real ~ normal(0., 1.) T[-1., ];
+  x_real ~ normal(0., 1.) T[ , ];
+
+  // transformation on lhs of sampling
+  log(x_real) ~ normal(0., 1.);
+
+  // lhs indexes
+  y[1] = 1.;
+  A[1, 2] = 1.;
+  A[1][2] = 1.;
+
+  // special functions
+  odeout = integrate_ode(ode_func, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, x_real, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>0<endfold id='2'>}</endfold id='2'>);
+  odeout = integrate_ode_bdf(ode_func, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, x_real, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>0<endfold id='2'>}</endfold id='2'>,
+                             x_real, x_real, x_int);
+  odeout = integrate_ode_rk45(ode_func, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, x_real, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>1.<endfold id='2'>}</endfold id='2'>, <beginfold id='2'>{</beginfold id='2'>0<endfold id='2'>}</endfold id='2'>,
+                              x_real, x_real, x_int);
+  // algout = algebra_solver(algebra_func, x_vector, x_vector, {1.}, {0});
+
+  // distribution functions
+  x = normal_lpdf(0.5 | 0., 1.);
+  x = normal_cdf(0.5, 0., 1.);
+  x = normal_lcdf(0.5 | 0., 1.);
+  x = normal_lccdf(0.5 | 0., 1.);
+  x = binomial_lpmf(1 | 2, 0.5);
+
+  // deprecated features
+  foo <- 1;
+  increment_log_prob(0.0);
+  y_hat = integrate_ode(sho, y0, t0, ts, theta, x_r, x_i);
+  x = get_lp();
+  x = multiply_log(1.0, 1.0);
+  x = binomial_coefficient_log(1.0, 1.0);
+  // deprecated distribution functions versions
+  x = normal_log(0.5, 0.0, 1.0);
+  x = normal_cdf_log(0.5, 0.0, 1.0);
+  x = normal_ccdf_log(0.5, 0.0, 1.0);
+
+<endfold id='2'>}</endfold id='2'>
+generated quantities <beginfold id='2'>{</beginfold id='2'>
+  real Y;
+  // rng function
+  Y = normal_rng(0., 1.);
+<endfold id='2'>}</endfold id='2'>

--- a/autotests/html/highlight.stan.html
+++ b/autotests/html/highlight.stan.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>highlight.stan</title>
+<meta name="generator" content="KF5::SyntaxHighlighting (Stan)"/>
+</head><body style="color:#1f1c1b"><pre>
+<span style="color:#898887;">/* Stan Highlighting Example</span>
+
+<span style="color:#898887;">  This file contains a syntatically correct but nonsensical Stan program that</span>
+<span style="color:#898887;">  includes almost every feature of the language needed to validate syntax</span>
+<span style="color:#898887;">  highlighters. It will compile (as of Stan 2.17.1), but it does nothing</span>
+<span style="color:#898887;">  useful.</span>
+
+<span style="color:#898887;">  Author: Jeffrey Arnold &lt;jeffrey.anold@gmail.com&gt;</span>
+<span style="color:#898887;">  Copyright: Jeffrey Arnold (2018)</span>
+<span style="color:#898887;">  License: MIT</span>
+
+<span style="color:#898887;">*/</span>
+<span style="color:#898887;">// line comment</span>
+<span style="color:#898887;"># deprecated line comment</span>
+<span style="font-weight:bold;">functions</span> {
+  <span style="color:#898887;">#include stuff.stan</span>
+  <span style="color:#898887;">#include &quot;morestuff.stan&quot;</span>
+  <span style="color:#898887;">#include 'moststuff.stan'</span>
+  <span style="color:#898887;">#include &lt;evenmorestuff.stan&gt;</span>
+
+  <span style="color:#898887;">// declarations</span>
+  <span style="color:#0057ae;">void</span> oof(<span style="color:#0057ae;">real</span> x);
+
+  <span style="color:#898887;">// definitions</span>
+  <span style="color:#898887;">// return types</span>
+  <span style="color:#0057ae;">void</span> oof(<span style="color:#0057ae;">real</span> x) {
+    <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;print &quot;</span>, x);
+  }
+  <span style="color:#898887;">/*</span>
+<span style="color:#898887;">    </span><span style="color:#ca60ca;">@param</span><span style="color:#898887;"> x A number</span>
+<span style="color:#898887;">    </span><span style="color:#ca60ca;">@return</span><span style="color:#898887;"> x + 1</span>
+<span style="color:#898887;">  */</span>
+  <span style="color:#0057ae;">real</span> foo(<span style="color:#0057ae;">real</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">int</span> bar(<span style="color:#0057ae;">int</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">vector</span> baz(<span style="color:#0057ae;">vector</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">row_vector</span> qux(<span style="color:#0057ae;">row_vector</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">matrix</span> quux(<span style="color:#0057ae;">matrix</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#898887;">// numbers of arguments</span>
+  <span style="color:#0057ae;">void</span> corge() {
+    <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;no parameters&quot;</span>);
+  }
+  <span style="color:#0057ae;">void</span> grault(<span style="color:#0057ae;">int</span> a, <span style="color:#0057ae;">real</span> b, <span style="color:#0057ae;">vector</span> c, <span style="color:#0057ae;">row_vector</span> d, <span style="color:#0057ae;">matrix</span> f) {
+    <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;many parameters&quot;</span>);
+  }
+  <span style="color:#0057ae;">void</span> garply(<span style="color:#0057ae;">real</span> a, <span style="color:#0057ae;">real</span>[] b, <span style="color:#0057ae;">real</span>[,] c, <span style="color:#0057ae;">real</span>[,,] d) {
+    <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;array arguments&quot;</span>);
+  }
+  <span style="color:#898887;">// array return types</span>
+  <span style="color:#0057ae;">int</span>[] waldo(<span style="color:#0057ae;">int</span>[] x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">int</span>[,] fred(<span style="color:#0057ae;">int</span>[,] x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#0057ae;">int</span>[,,] plough(<span style="color:#0057ae;">int</span>[,,] x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#898887;">// data only function argument</span>
+  <span style="color:#0057ae;">real</span> plugh(<span style="font-weight:bold;">data</span> <span style="color:#0057ae;">real</span> x) {
+    <span style="font-weight:bold;">return</span> x;
+  }
+  <span style="color:#898887;">// ode function</span>
+  <span style="color:#0057ae;">real</span>[] ode_func(<span style="color:#0057ae;">real</span> a, <span style="color:#0057ae;">real</span>[] b, <span style="color:#0057ae;">real</span>[] c, <span style="color:#0057ae;">real</span>[] d, <span style="color:#0057ae;">int</span>[] e) {
+    <span style="font-weight:bold;">return</span> b;
+  }
+}
+<span style="font-weight:bold;">data</span> {
+  <span style="color:#898887;">// non-int variable types</span>
+  <span style="color:#0057ae;">int</span> x_int;
+  <span style="color:#0057ae;">real</span> x_real;
+  <span style="color:#0057ae;">real</span> y_real;
+  <span style="color:#0057ae;">vector</span>[<span style="color:#b08000;">1</span>] x_vector;
+  <span style="color:#0057ae;">ordered</span>[<span style="color:#b08000;">1</span>] x_ordered;
+  <span style="color:#0057ae;">positive_ordered</span>[<span style="color:#b08000;">1</span>] x_positive_ordered;
+  <span style="color:#0057ae;">simplex</span>[<span style="color:#b08000;">1</span>] x_simplex;
+  <span style="color:#0057ae;">unit_vector</span>[<span style="color:#b08000;">1</span>] x_unit_vector;
+  <span style="color:#0057ae;">row_vector</span>[<span style="color:#b08000;">1</span>] x_row_vector;
+  <span style="color:#0057ae;">matrix</span>[<span style="color:#b08000;">1</span>, <span style="color:#b08000;">1</span>] x_matrix;
+  <span style="color:#0057ae;">cholesky_factor_corr</span>[<span style="color:#b08000;">2</span>] x_cholesky_factor_corr;
+  <span style="color:#0057ae;">cholesky_factor_cov</span>[<span style="color:#b08000;">2</span>] x_cholesky_factor_cov;
+  <span style="color:#0057ae;">cholesky_factor_cov</span>[<span style="color:#b08000;">2</span>, <span style="color:#b08000;">3</span>] x_cholesky_factor_cov_2;
+  <span style="color:#0057ae;">corr_matrix</span>[<span style="color:#b08000;">2</span>] x_corr_matrix;
+  <span style="color:#0057ae;">cov_matrix</span>[<span style="color:#b08000;">2</span>] x_cov_matrix;
+
+  <span style="color:#898887;">// range constraints</span>
+  <span style="color:#0057ae;">real</span>&lt;<span style="font-weight:bold;">lower</span> = <span style="color:#b08000;">0.</span>, <span style="font-weight:bold;">upper</span> = <span style="color:#b08000;">1.</span>&gt; alpha;
+  <span style="color:#0057ae;">real</span>&lt;<span style="font-weight:bold;">lower</span> = <span style="color:#b08000;">0.</span>&gt; bravo;
+  <span style="color:#0057ae;">real</span>&lt;<span style="font-weight:bold;">upper</span> = <span style="color:#b08000;">1.</span>&gt; charlie;
+
+  <span style="color:#898887;">// arrays</span>
+  <span style="color:#0057ae;">int</span> echo[<span style="color:#b08000;">1</span>];
+  <span style="color:#0057ae;">int</span> foxtrot[<span style="color:#b08000;">1</span>, <span style="color:#b08000;">1</span>];
+  <span style="color:#0057ae;">int</span> golf[<span style="color:#b08000;">1</span>, <span style="color:#b08000;">1</span>, <span style="color:#b08000;">1</span>];
+
+  <span style="color:#898887;">// identifier with all valid letters</span>
+  <span style="color:#0057ae;">real</span> abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789;
+
+  <span style="color:#898887;">// hard pattern</span>
+  <span style="color:#0057ae;">real</span>&lt;<span style="font-weight:bold;">lower</span> = (bravo &lt; charlie), <span style="font-weight:bold;">upper</span> = (bravo &gt; charlie)&gt; ranger;
+
+  <span style="color:#898887;">// identifier patterns</span>
+  <span style="color:#0057ae;">real</span> a;
+  <span style="color:#0057ae;">real</span> a3;
+  <span style="color:#0057ae;">real</span> a_3;
+  <span style="color:#0057ae;">real</span> Sigma;
+  <span style="color:#0057ae;">real</span> my_cpp_style_variable;
+  <span style="color:#0057ae;">real</span> myCamelCaseVariable;
+  <span style="color:#0057ae;">real</span> abcdefghijklmnojk;
+  <span style="color:#898887;">// names beginning with keywords</span>
+  <span style="color:#0057ae;">real</span> iffffff;
+  <span style="color:#0057ae;">real</span> whilest;
+  <span style="color:#898887;">// name ending with truncation</span>
+  <span style="color:#0057ae;">real</span> fooT;
+}
+<span style="font-weight:bold;">transformed data</span> {
+  <span style="color:#898887;">// declaration and assignment</span>
+  <span style="color:#0057ae;">int</span> india = <span style="color:#b08000;">1</span>;
+  <span style="color:#0057ae;">real</span> romeo = <span style="color:#b08000;">1.0</span>;
+  <span style="color:#0057ae;">row_vector</span>[<span style="color:#b08000;">2</span>] victor = [<span style="color:#b08000;">1</span>, <span style="color:#b08000;">2</span>];
+  <span style="color:#0057ae;">matrix</span>[<span style="color:#b08000;">2</span>, <span style="color:#b08000;">2</span>] mike = [[<span style="color:#b08000;">1</span>, <span style="color:#b08000;">2</span>], [<span style="color:#b08000;">3</span>, <span style="color:#b08000;">4</span>]];
+  <span style="color:#0057ae;">real</span> sierra[<span style="color:#b08000;">2</span>] = {<span style="color:#b08000;">1.</span>, <span style="color:#b08000;">2.</span>};
+}
+<span style="font-weight:bold;">parameters</span> {
+  <span style="color:#0057ae;">real</span> hotel;
+}
+<span style="font-weight:bold;">transformed parameters</span> {
+  <span style="color:#0057ae;">real</span> juliette;
+  juliette = hotel * <span style="color:#b08000;">2.</span>;
+}
+<span style="font-weight:bold;">model</span> {
+  <span style="color:#0057ae;">real</span> x;
+  <span style="color:#0057ae;">int</span> k;
+  <span style="color:#0057ae;">vector</span>[<span style="color:#b08000;">2</span>] y = [<span style="color:#b08000;">1.</span>, <span style="color:#b08000;">1.</span>]';
+  <span style="color:#0057ae;">matrix</span>[<span style="color:#b08000;">2</span>, <span style="color:#b08000;">2</span>] A = [[<span style="color:#b08000;">1.</span>, <span style="color:#b08000;">1.</span>], [<span style="color:#b08000;">1.</span>, <span style="color:#b08000;">1.</span>]];
+  <span style="color:#0057ae;">real</span> odeout[<span style="color:#b08000;">2</span>, <span style="color:#b08000;">2</span>];
+  <span style="color:#0057ae;">real</span> algout[<span style="color:#b08000;">2</span>, <span style="color:#b08000;">2</span>];
+
+  <span style="color:#898887;">// if else statements</span>
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) x = <span style="color:#b08000;">0.</span>;
+
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) {
+    x = <span style="color:#b08000;">0.</span>;
+  }
+
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) x = <span style="color:#b08000;">0.</span>;
+  <span style="font-weight:bold;">else</span> x = <span style="color:#b08000;">1.</span>;
+
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) {
+    x = <span style="color:#b08000;">0.</span>;
+  } <span style="font-weight:bold;">else</span> {
+    x = <span style="color:#b08000;">1.</span>;
+  }
+
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) x = <span style="color:#b08000;">0.</span>;
+  <span style="font-weight:bold;">else</span> <span style="font-weight:bold;">if</span> (x_real &gt; <span style="color:#b08000;">1</span>) x = <span style="color:#b08000;">1.</span>;
+  <span style="font-weight:bold;">else</span> x = <span style="color:#b08000;">0.5</span>;
+
+  <span style="font-weight:bold;">if</span> (x_real &lt; <span style="color:#b08000;">0</span>) {
+    x = <span style="color:#b08000;">0.</span>;
+  } <span style="font-weight:bold;">else</span> <span style="font-weight:bold;">if</span> (x_real &gt; <span style="color:#b08000;">1</span>) {
+    x = <span style="color:#b08000;">1.</span>;
+  } <span style="font-weight:bold;">else</span> {
+    x = <span style="color:#b08000;">0.5</span>;
+  }
+
+  <span style="color:#898887;">// for loops</span>
+  <span style="font-weight:bold;">for</span> (i <span style="font-weight:bold;">in</span> <span style="color:#b08000;">1</span>:<span style="color:#b08000;">5</span>) {
+    <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;i = &quot;</span>, i);
+  }
+  <span style="color:#898887;">// for (j in echo) {</span>
+  <span style="color:#898887;">//   print(&quot;j = &quot;, j);</span>
+  <span style="color:#898887;">// }</span>
+  <span style="color:#898887;">// while loop</span>
+  <span style="font-weight:bold;">while</span> (<span style="color:#b08000;">1</span>) {
+    <span style="font-weight:bold;">break</span>;
+    <span style="font-weight:bold;">continue</span>;
+  }
+
+  <span style="color:#898887;">// reject statement</span>
+  <span style="font-weight:bold;">reject</span>(<span style="color:#bf0303;">&quot;reject statment &quot;</span>, x_real);
+
+  <span style="color:#898887;">// print statement</span>
+  <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;print statement &quot;</span>, x_real);
+  <span style="font-weight:bold;">print</span>(<span style="color:#bf0303;">&quot;abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_~@#$%^&amp;*`'-+={}[].,;: &quot;</span>);
+
+  <span style="color:#898887;">// increment log probability statements;</span>
+  <span style="font-weight:bold;">target +=</span> <span style="color:#b08000;">1.</span>;
+
+  <span style="color:#898887;">// valid integer literals</span>
+  k = <span style="color:#b08000;">0</span>;
+  k = <span style="color:#b08000;">1</span>;
+  k = -<span style="color:#b08000;">1</span>;
+  k = <span style="color:#b08000;">256</span>;
+  k = -<span style="color:#b08000;">127098</span>;
+  k = <span style="color:#b08000;">007</span>;
+
+  <span style="color:#898887;">// valid real literals</span>
+  x = <span style="color:#b08000;">0.0</span>;
+  x = <span style="color:#b08000;">1.0</span>;
+  x = <span style="color:#b08000;">3.14</span>;
+  x = <span style="color:#b08000;">003.14</span>;
+  x = -<span style="color:#b08000;">217.9387</span>;
+  x = <span style="color:#b08000;">0.123</span>;
+  x = <span style="color:#b08000;">.123</span>;
+  x = <span style="color:#b08000;">1.</span>;
+  x = -<span style="color:#b08000;">0.123</span>;
+  x = -<span style="color:#b08000;">.123</span>;
+  x = -<span style="color:#b08000;">1.</span>;
+  x = <span style="color:#b08000;">12</span>e34;
+  x = <span style="color:#b08000;">12</span>E34;
+  x = <span style="color:#b08000;">12.e34</span>;
+  x = <span style="color:#b08000;">12.E34</span>;
+  x = <span style="color:#b08000;">12.0e34</span>;
+  x = <span style="color:#b08000;">12.0E34</span>;
+  x = <span style="color:#b08000;">.1e34</span>;
+  x = <span style="color:#b08000;">.1E34</span>;
+  x = -<span style="color:#b08000;">12</span>e34;
+  x = -<span style="color:#b08000;">12</span>E34;
+  x = -<span style="color:#b08000;">12.e34</span>;
+  x = -<span style="color:#b08000;">12.E34</span>;
+  x = -<span style="color:#b08000;">12.0e34</span>;
+  x = -<span style="color:#b08000;">12.0E34</span>;
+  x = -<span style="color:#b08000;">.1e34</span>;
+  x = -<span style="color:#b08000;">.1E34</span>;
+  x = <span style="color:#b08000;">12</span>e-<span style="color:#b08000;">34</span>;
+  x = <span style="color:#b08000;">12</span>E-<span style="color:#b08000;">34</span>;
+  x = <span style="color:#b08000;">12.e-34</span>;
+  x = <span style="color:#b08000;">12.E-34</span>;
+  x = <span style="color:#b08000;">12.0e-34</span>;
+  x = <span style="color:#b08000;">12.0E-34</span>;
+  x = <span style="color:#b08000;">.1e-34</span>;
+  x = <span style="color:#b08000;">.1E-34</span>;
+  x = -<span style="color:#b08000;">12</span>e-<span style="color:#b08000;">34</span>;
+  x = -<span style="color:#b08000;">12</span>E-<span style="color:#b08000;">34</span>;
+  x = -<span style="color:#b08000;">12.e-34</span>;
+  x = -<span style="color:#b08000;">12.E-34</span>;
+  x = -<span style="color:#b08000;">12.0e-34</span>;
+  x = -<span style="color:#b08000;">12.0E-34</span>;
+  x = -<span style="color:#b08000;">.1e-34</span>;
+  x = -<span style="color:#b08000;">.1E-34</span>;
+  x = <span style="color:#b08000;">12</span>e+<span style="color:#b08000;">34</span>;
+  x = <span style="color:#b08000;">12</span>E+<span style="color:#b08000;">34</span>;
+  x = <span style="color:#b08000;">12.e+34</span>;
+  x = <span style="color:#b08000;">12.E+34</span>;
+  x = <span style="color:#b08000;">12.0e+34</span>;
+  x = <span style="color:#b08000;">12.0E+34</span>;
+  x = <span style="color:#b08000;">.1e+34</span>;
+  x = <span style="color:#b08000;">.1E+34</span>;
+  x = -<span style="color:#b08000;">12</span>e+<span style="color:#b08000;">34</span>;
+  x = -<span style="color:#b08000;">12</span>E+<span style="color:#b08000;">34</span>;
+  x = -<span style="color:#b08000;">12.e+34</span>;
+  x = -<span style="color:#b08000;">12.E+34</span>;
+  x = -<span style="color:#b08000;">12.0e+34</span>;
+  x = -<span style="color:#b08000;">12.0E+34</span>;
+  x = -<span style="color:#b08000;">.1e+34</span>;
+  x = -<span style="color:#b08000;">.1E+34</span>;
+
+  <span style="color:#898887;">// assignment statements</span>
+  x = <span style="color:#b08000;">1</span>;
+  x += <span style="color:#b08000;">1.</span>;
+  x -= <span style="color:#b08000;">1.</span>;
+  x *= <span style="color:#b08000;">1.</span>;
+  x /= <span style="color:#b08000;">1.</span>;
+  y .*= x_vector;
+  y ./= x_vector;
+
+  <span style="color:#898887;">// operators</span>
+  x = x_real &amp;&amp; <span style="color:#b08000;">1</span>;
+  x = x_real || <span style="color:#b08000;">1</span>;
+  x = x_real &lt; <span style="color:#b08000;">1.</span>;
+  x = x_real &lt;= <span style="color:#b08000;">1.</span>;
+  x = x_real &gt; <span style="color:#b08000;">1.</span>;
+  x = x_real &gt;= <span style="color:#b08000;">1.</span>;
+  x = x_real + <span style="color:#b08000;">1.</span>;
+  x = x_real - <span style="color:#b08000;">1.</span>;
+  x = x_real * <span style="color:#b08000;">1.</span>;
+  x = x_real / <span style="color:#b08000;">1.</span>;
+  x = x_real ^ <span style="color:#b08000;">2.</span>;
+  x = x_real % <span style="color:#b08000;">2</span>;
+  x = !x_real;
+  x = +x_real;
+  x = -x_real;
+  x = x_int ? x_real : <span style="color:#b08000;">0.</span>;
+
+  y = x_row_vector';
+  y = x_matrix \ x_vector;
+  y = x_vector .* x_vector;
+  y = x_vector ./ x_vector;
+
+  <span style="color:#898887;">// parenthized expression</span>
+  x = (x_real + x_real);
+
+  <span style="color:#898887;">// block statement</span>
+  {
+    <span style="color:#0057ae;">real</span> z;
+    z = <span style="color:#b08000;">1.</span>;
+  }
+
+  <span style="color:#898887;">// built-in functions</span>
+  x = log(<span style="color:#b08000;">1.</span>);
+  x = exp(<span style="color:#b08000;">1.</span>);
+
+  <span style="color:#898887;">// non-built-in function</span>
+  x = foo(<span style="color:#b08000;">1.</span>);
+
+  <span style="color:#898887;">// constants and nullary functions</span>
+  x = machine_precision();
+  x = pi();
+  x = e();
+  x = sqrt2();
+  x = log2();
+  x = log10();
+  <span style="color:#898887;">// special values</span>
+  x = not_a_number();
+  x = positive_infinity();
+  x = negative_infinity();
+  x = machine_precision();
+  <span style="color:#898887;">// log probability</span>
+  x = target();
+
+  <span style="color:#898887;">// sampling statement</span>
+  x_real ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+
+  <span style="color:#898887;">// truncation</span>
+  x_real ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>) <span style="font-weight:bold;">T</span>[-<span style="color:#b08000;">1.</span>, <span style="color:#b08000;">1.</span>];
+  x_real ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>) <span style="font-weight:bold;">T</span>[, <span style="color:#b08000;">1.</span>];
+  x_real ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>) <span style="font-weight:bold;">T</span>[-<span style="color:#b08000;">1.</span>, ];
+  x_real ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>) <span style="font-weight:bold;">T</span>[ , ];
+
+  <span style="color:#898887;">// transformation on lhs of sampling</span>
+  log(x_real) ~ normal(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+
+  <span style="color:#898887;">// lhs indexes</span>
+  y[<span style="color:#b08000;">1</span>] = <span style="color:#b08000;">1.</span>;
+  A[<span style="color:#b08000;">1</span>, <span style="color:#b08000;">2</span>] = <span style="color:#b08000;">1.</span>;
+  A[<span style="color:#b08000;">1</span>][<span style="color:#b08000;">2</span>] = <span style="color:#b08000;">1.</span>;
+
+  <span style="color:#898887;">// special functions</span>
+  odeout = <span style="font-weight:bold;">integrate_ode</span>(ode_func, {<span style="color:#b08000;">1.</span>}, x_real, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">0</span>});
+  odeout = <span style="font-weight:bold;">integrate_ode_bdf</span>(ode_func, {<span style="color:#b08000;">1.</span>}, x_real, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">0</span>},
+                             x_real, x_real, x_int);
+  odeout = <span style="font-weight:bold;">integrate_ode_rk45</span>(ode_func, {<span style="color:#b08000;">1.</span>}, x_real, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">1.</span>}, {<span style="color:#b08000;">0</span>},
+                              x_real, x_real, x_int);
+  <span style="color:#898887;">// algout = algebra_solver(algebra_func, x_vector, x_vector, {1.}, {0});</span>
+
+  <span style="color:#898887;">// distribution functions</span>
+  x = normal_lpdf(<span style="color:#b08000;">0.5</span> | <span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+  x = normal_cdf(<span style="color:#b08000;">0.5</span>, <span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+  x = normal_lcdf(<span style="color:#b08000;">0.5</span> | <span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+  x = normal_lccdf(<span style="color:#b08000;">0.5</span> | <span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+  x = binomial_lpmf(<span style="color:#b08000;">1</span> | <span style="color:#b08000;">2</span>, <span style="color:#b08000;">0.5</span>);
+
+  <span style="color:#898887;">// deprecated features</span>
+  foo &lt;- <span style="color:#b08000;">1</span>;
+  increment_log_prob(<span style="color:#b08000;">0.0</span>);
+  y_hat = <span style="font-weight:bold;">integrate_ode</span>(sho, y0, t0, ts, theta, x_r, x_i);
+  x = get_lp();
+  x = multiply_log(<span style="color:#b08000;">1.0</span>, <span style="color:#b08000;">1.0</span>);
+  x = binomial_coefficient_log(<span style="color:#b08000;">1.0</span>, <span style="color:#b08000;">1.0</span>);
+  <span style="color:#898887;">// deprecated distribution functions versions</span>
+  x = normal_log(<span style="color:#b08000;">0.5</span>, <span style="color:#b08000;">0.0</span>, <span style="color:#b08000;">1.0</span>);
+  x = normal_cdf_log(<span style="color:#b08000;">0.5</span>, <span style="color:#b08000;">0.0</span>, <span style="color:#b08000;">1.0</span>);
+  x = normal_ccdf_log(<span style="color:#b08000;">0.5</span>, <span style="color:#b08000;">0.0</span>, <span style="color:#b08000;">1.0</span>);
+
+}
+<span style="font-weight:bold;">generated quantities</span> {
+  <span style="color:#0057ae;">real</span> Y;
+  <span style="color:#898887;">// rng function</span>
+  Y = normal_rng(<span style="color:#b08000;">0.</span>, <span style="color:#b08000;">1.</span>);
+}
+</pre></body></html>

--- a/autotests/reference/highlight.stan.ref
+++ b/autotests/reference/highlight.stan.ref
@@ -1,0 +1,380 @@
+<Comment>/* Stan Highlighting Example</Comment><br/>
+<dsNormal></dsNormal><br/>
+<Comment>  This file contains a syntatically correct but nonsensical Stan program that</Comment><br/>
+<Comment>  includes almost every feature of the language needed to validate syntax</Comment><br/>
+<Comment>  highlighters. It will compile (as of Stan 2.17.1), but it does nothing</Comment><br/>
+<Comment>  useful.</Comment><br/>
+<dsNormal></dsNormal><br/>
+<Comment>  Author: Jeffrey Arnold <jeffrey.anold@gmail.com></Comment><br/>
+<Comment>  Copyright: Jeffrey Arnold (2018)</Comment><br/>
+<Comment>  License: MIT</Comment><br/>
+<dsNormal></dsNormal><br/>
+<Comment>*/</Comment><br/>
+<Comment>// line comment</Comment><br/>
+<Comment># deprecated line comment</Comment><br/>
+<Keyword>functions</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>#include stuff.stan</Comment><br/>
+<Normal Text>  </Normal Text><Comment>#include "morestuff.stan"</Comment><br/>
+<Normal Text>  </Normal Text><Comment>#include 'moststuff.stan'</Comment><br/>
+<Normal Text>  </Normal Text><Comment>#include <evenmorestuff.stan></Comment><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// declarations</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>void</Data Type><Normal Text> </Normal Text><Identifier>oof</Identifier><Punctuation>(</Punctuation><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// definitions</Comment><br/>
+<Normal Text>  </Normal Text><Comment>// return types</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>void</Data Type><Normal Text> </Normal Text><Identifier>oof</Identifier><Punctuation>(</Punctuation><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"print "</String><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>/*</Comment><br/>
+<Comment>    </Comment><Doc Tag>@param</Doc Tag><Comment> x A number</Comment><br/>
+<Comment>    </Comment><Doc Tag>@return</Doc Tag><Comment> x + 1</Comment><br/>
+<Comment>  */</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>foo</Identifier><Punctuation>(</Punctuation><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>bar</Identifier><Punctuation>(</Punctuation><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>vector</Data Type><Normal Text> </Normal Text><Identifier>baz</Identifier><Punctuation>(</Punctuation><Data Type>vector</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>row_vector</Data Type><Normal Text> </Normal Text><Identifier>qux</Identifier><Punctuation>(</Punctuation><Data Type>row_vector</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>matrix</Data Type><Normal Text> </Normal Text><Identifier>quux</Identifier><Punctuation>(</Punctuation><Data Type>matrix</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// numbers of arguments</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>void</Data Type><Normal Text> </Normal Text><Identifier>corge</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"no parameters"</String><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>void</Data Type><Normal Text> </Normal Text><Identifier>grault</Identifier><Punctuation>(</Punctuation><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>a</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>b</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>vector</Data Type><Normal Text> </Normal Text><Identifier>c</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>row_vector</Data Type><Normal Text> </Normal Text><Identifier>d</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>matrix</Data Type><Normal Text> </Normal Text><Identifier>f</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"many parameters"</String><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>void</Data Type><Normal Text> </Normal Text><Identifier>garply</Identifier><Punctuation>(</Punctuation><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>a</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>b</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[,]</Punctuation><Normal Text> </Normal Text><Identifier>c</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[,,]</Punctuation><Normal Text> </Normal Text><Identifier>d</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"array arguments"</String><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// array return types</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>waldo</Identifier><Punctuation>(</Punctuation><Data Type>int</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Punctuation>[,]</Punctuation><Normal Text> </Normal Text><Identifier>fred</Identifier><Punctuation>(</Punctuation><Data Type>int</Data Type><Punctuation>[,]</Punctuation><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Punctuation>[,,]</Punctuation><Normal Text> </Normal Text><Identifier>plough</Identifier><Punctuation>(</Punctuation><Data Type>int</Data Type><Punctuation>[,,]</Punctuation><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// data only function argument</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>plugh</Identifier><Punctuation>(</Punctuation><Keyword>data</Keyword><Normal Text> </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// ode function</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>ode_func</Identifier><Punctuation>(</Punctuation><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>a</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>b</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>c</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>real</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>d</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Data Type>int</Data Type><Punctuation>[]</Punctuation><Normal Text> </Normal Text><Identifier>e</Identifier><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>return</Control Flow><Normal Text> </Normal Text><Identifier>b</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>data</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// non-int variable types</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>x_int</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>y_real</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>vector</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>ordered</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_ordered</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>positive_ordered</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_positive_ordered</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>simplex</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_simplex</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>unit_vector</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_unit_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>row_vector</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_row_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>matrix</Data Type><Punctuation>[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_matrix</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>cholesky_factor_corr</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_cholesky_factor_corr</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>cholesky_factor_cov</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_cholesky_factor_cov</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>cholesky_factor_cov</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>3</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_cholesky_factor_cov_2</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>corr_matrix</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_corr_matrix</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>cov_matrix</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>x_cov_matrix</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// range constraints</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Operator><</Operator><Keyword>lower</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Keyword>upper</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>></Operator><Normal Text> </Normal Text><Identifier>alpha</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Operator><</Operator><Keyword>lower</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Real>0.</Real><Operator>></Operator><Normal Text> </Normal Text><Identifier>bravo</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Operator><</Operator><Keyword>upper</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>></Operator><Normal Text> </Normal Text><Identifier>charlie</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// arrays</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>echo</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>foxtrot</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>1</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>golf</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>1</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// identifier with all valid letters</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// hard pattern</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Operator><</Operator><Keyword>lower</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>bravo</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Identifier>charlie</Identifier><Operator>)</Operator><Punctuation>,</Punctuation><Normal Text> </Normal Text><Keyword>upper</Keyword><Normal Text> </Normal Text><Punctuation>=</Punctuation><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>bravo</Identifier><Normal Text> </Normal Text><Operator>></Operator><Normal Text> </Normal Text><Identifier>charlie</Identifier><Operator>)></Operator><Normal Text> </Normal Text><Identifier>ranger</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// identifier patterns</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>a</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>a3</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>a_3</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>Sigma</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>my_cpp_style_variable</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>myCamelCaseVariable</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>abcdefghijklmnojk</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// names beginning with keywords</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>iffffff</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>whilest</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// name ending with truncation</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>fooT</Identifier><Normal Text>;</Normal Text><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>transformed data</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// declaration and assignment</Comment><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>india</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>romeo</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.0</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>row_vector</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>victor</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>matrix</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>mike</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>[[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>],</Punctuation><Normal Text> </Normal Text><Punctuation>[</Punctuation><Int>3</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>4</Int><Punctuation>]]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>sierra</Identifier><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>2.</Real><Punctuation>}</Punctuation><Normal Text>;</Normal Text><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>parameters</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>hotel</Identifier><Normal Text>;</Normal Text><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>transformed parameters</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>juliette</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>juliette</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>hotel</Identifier><Normal Text> </Normal Text><Operator>*</Operator><Normal Text> </Normal Text><Real>2.</Real><Normal Text>;</Normal Text><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>model</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>int</Data Type><Normal Text> </Normal Text><Identifier>k</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>vector</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>[</Punctuation><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Punctuation>]</Punctuation><Operator>'</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>matrix</Data Type><Punctuation>[</Punctuation><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Identifier>A</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>[[</Punctuation><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Punctuation>],</Punctuation><Normal Text> </Normal Text><Punctuation>[</Punctuation><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Punctuation>]]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>odeout</Identifier><Punctuation>[</Punctuation><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>algout</Identifier><Punctuation>[</Punctuation><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// if else statements</Comment><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><Normal Text> </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>></Operator><Normal Text> </Normal Text><Int>1</Int><Operator>)</Operator><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.5</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Int>0</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><Normal Text> </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Control Flow>if</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>></Operator><Normal Text> </Normal Text><Int>1</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><Normal Text> </Normal Text><Control Flow>else</Control Flow><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.5</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// for loops</Comment><br/>
+<Normal Text>  </Normal Text><Control Flow>for</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>i</Identifier><Normal Text> </Normal Text><Control Flow>in</Control Flow><Normal Text> </Normal Text><Int>1</Int><Operator>:</Operator><Int>5</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"i = "</String><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>i</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<Normal Text>  </Normal Text><Comment>// for (j in echo) {</Comment><br/>
+<Normal Text>  </Normal Text><Comment>//   print("j = ", j);</Comment><br/>
+<Normal Text>  </Normal Text><Comment>// }</Comment><br/>
+<Normal Text>  </Normal Text><Comment>// while loop</Comment><br/>
+<Normal Text>  </Normal Text><Control Flow>while</Control Flow><Normal Text> </Normal Text><Punctuation>(</Punctuation><Int>1</Int><Operator>)</Operator><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Control Flow>break</Control Flow><Normal Text>;</Normal Text><br/>
+<Normal Text>    </Normal Text><Control Flow>continue</Control Flow><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// reject statement</Comment><br/>
+<Normal Text>  </Normal Text><Keyword>reject</Keyword><Punctuation>(</Punctuation><String>"reject statment "</String><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// print statement</Comment><br/>
+<Normal Text>  </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"print statement "</String><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Keyword>print</Keyword><Punctuation>(</Punctuation><String>"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_~@#$%^&*`'-+={}[].,;: "</String><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// increment log probability statements;</Comment><br/>
+<Normal Text>  </Normal Text><Keyword>target +=</Keyword><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// valid integer literals</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>0</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>256</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>127098</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>k</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>007</Int><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// valid real literals</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.0</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.0</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>3.14</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>003.14</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>217.9387</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>0.123</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.123</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>0.123</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.123</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>e34</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>E34</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>e34</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>E34</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1e34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1E34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>e</Identifier><Operator>-</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>E</Identifier><Operator>-</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>e</Identifier><Operator>-</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>E</Identifier><Operator>-</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1e-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1E-34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>e</Identifier><Operator>+</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>12</Int><Identifier>E</Identifier><Operator>+</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.E+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>12.0E+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>.1E+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>e</Identifier><Operator>+</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Int>12</Int><Identifier>E</Identifier><Operator>+</Operator><Int>34</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.E+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>12.0E+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1e+34</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Real>.1E+34</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// assignment statements</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>+=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>-=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>*=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>/=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>.*=</Assignment><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>./=</Assignment><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// operators</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>&&</Operator><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>||</Operator><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator><</Operator><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>></Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>>=</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>+</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>-</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>*</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>/</Operator><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> ^ </Normal Text><Real>2.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>%</Operator><Normal Text> </Normal Text><Int>2</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> !</Normal Text><Identifier>x_real</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>+</Operator><Identifier>x_real</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Operator>-</Operator><Identifier>x_real</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_int</Identifier><Normal Text> </Normal Text><Operator>?</Operator><Normal Text> </Normal Text><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>:</Operator><Normal Text> </Normal Text><Real>0.</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_row_vector</Identifier><Operator>'</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_matrix</Identifier><Normal Text> </Normal Text><Operator>\</Operator><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text> </Normal Text><Operator>.*</Operator><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text> </Normal Text><Operator>./</Operator><Normal Text> </Normal Text><Identifier>x_vector</Identifier><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// parenthized expression</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Normal Text> </Normal Text><Operator>+</Operator><Normal Text> </Normal Text><Identifier>x_real</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// block statement</Comment><br/>
+<Normal Text>  </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>    </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>z</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>    </Normal Text><Identifier>z</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Punctuation>}</Punctuation><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// built-in functions</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>log</Identifier><Punctuation>(</Punctuation><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>exp</Identifier><Punctuation>(</Punctuation><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// non-built-in function</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>foo</Identifier><Punctuation>(</Punctuation><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// constants and nullary functions</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>machine_precision</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>pi</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>e</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>sqrt2</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>log2</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>log10</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// special values</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>not_a_number</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>positive_infinity</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>negative_infinity</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>machine_precision</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// log probability</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>target</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// sampling statement</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x_real</Identifier><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// truncation</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x_real</Identifier><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text> </Normal Text><Keyword>T</Keyword><Punctuation>[</Punctuation><Operator>-</Operator><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x_real</Identifier><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text> </Normal Text><Keyword>T</Keyword><Punctuation>[,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x_real</Identifier><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text> </Normal Text><Keyword>T</Keyword><Punctuation>[</Punctuation><Operator>-</Operator><Real>1.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x_real</Identifier><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text> </Normal Text><Keyword>T</Keyword><Punctuation>[</Punctuation><Normal Text> </Normal Text><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>]</Punctuation><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// transformation on lhs of sampling</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>log</Identifier><Punctuation>(</Punctuation><Identifier>x_real</Identifier><Operator>)</Operator><Normal Text> ~ </Normal Text><Identifier>normal</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// lhs indexes</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>y</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>A</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>A</Identifier><Punctuation>[</Punctuation><Int>1</Int><Punctuation>][</Punctuation><Int>2</Int><Punctuation>]</Punctuation><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Real>1.</Real><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// special functions</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>odeout</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Keyword>integrate_ode</Keyword><Punctuation>(</Punctuation><Identifier>ode_func</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Int>0</Int><Punctuation>}</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>odeout</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Keyword>integrate_ode_bdf</Keyword><Punctuation>(</Punctuation><Identifier>ode_func</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Int>0</Int><Punctuation>},</Punctuation><br/>
+<Normal Text>                             </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_int</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>odeout</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Keyword>integrate_ode_rk45</Keyword><Punctuation>(</Punctuation><Identifier>ode_func</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Real>1.</Real><Punctuation>},</Punctuation><Normal Text> </Normal Text><Punctuation>{</Punctuation><Int>0</Int><Punctuation>},</Punctuation><br/>
+<Normal Text>                              </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_real</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_int</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// algout = algebra_solver(algebra_func, x_vector, x_vector, {1.}, {0});</Comment><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// distribution functions</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_lpdf</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Normal Text> | </Normal Text><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_cdf</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_lcdf</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Normal Text> | </Normal Text><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_lccdf</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Normal Text> | </Normal Text><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>binomial_lpmf</Identifier><Punctuation>(</Punctuation><Int>1</Int><Normal Text> | </Normal Text><Int>2</Int><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>0.5</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Normal Text>  </Normal Text><Comment>// deprecated features</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>foo</Identifier><Normal Text> </Normal Text><Operator><-</Operator><Normal Text> </Normal Text><Int>1</Int><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>increment_log_prob</Identifier><Punctuation>(</Punctuation><Real>0.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>y_hat</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Keyword>integrate_ode</Keyword><Punctuation>(</Punctuation><Identifier>sho</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>y0</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>t0</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>ts</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>theta</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_r</Identifier><Punctuation>,</Punctuation><Normal Text> </Normal Text><Identifier>x_i</Identifier><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>get_lp</Identifier><Punctuation>(</Punctuation><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>multiply_log</Identifier><Punctuation>(</Punctuation><Real>1.0</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>binomial_coefficient_log</Identifier><Punctuation>(</Punctuation><Real>1.0</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// deprecated distribution functions versions</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_log</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>0.0</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_cdf_log</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>0.0</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Identifier>x</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_ccdf_log</Identifier><Punctuation>(</Punctuation><Real>0.5</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>0.0</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.0</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<dsNormal></dsNormal><br/>
+<Punctuation>}</Punctuation><br/>
+<Keyword>generated quantities</Keyword><Normal Text> </Normal Text><Punctuation>{</Punctuation><br/>
+<Normal Text>  </Normal Text><Data Type>real</Data Type><Normal Text> </Normal Text><Identifier>Y</Identifier><Normal Text>;</Normal Text><br/>
+<Normal Text>  </Normal Text><Comment>// rng function</Comment><br/>
+<Normal Text>  </Normal Text><Identifier>Y</Identifier><Normal Text> </Normal Text><Assignment>=</Assignment><Normal Text> </Normal Text><Identifier>normal_rng</Identifier><Punctuation>(</Punctuation><Real>0.</Real><Punctuation>,</Punctuation><Normal Text> </Normal Text><Real>1.</Real><Operator>)</Operator><Normal Text>;</Normal Text><br/>
+<Punctuation>}</Punctuation><br/>

--- a/data/syntax/stan.xml
+++ b/data/syntax/stan.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<language name="Stan"
+          section="Scientific"
+          version="1"
+          kateversion="5.0"
+          indenter="cstyle"
+          extensions="*.stan;*.stanfuncs"
+          license="MIT">
+  <highlighting>
+    <list name="controlflow">
+      <item>break</item>
+      <item>continue</item>
+      <item>else</item>
+      <item>for</item>
+      <item>if</item>
+      <item>in</item>
+      <item>return</item>
+      <item>while</item>
+    </list>
+    <list name="keywords">
+      <item>reject</item>
+      <item>print</item>
+      <item>integrate_ode</item>
+      <item>integrate_ode_bdf</item>
+      <item>integrate_ode_rk45</item>
+      <item>algebra_solver</item>
+    </list>
+    <list name="types">
+      <item>int</item>
+      <item>real</item>
+      <item>vector</item>
+      <item>ordered</item>
+      <item>positive_ordered</item>
+      <item>simplex</item>
+      <item>unit_vector</item>
+      <item>row_vector</item>
+      <item>matrix</item>
+      <item>cholesky_factor_corr</item>
+      <item>cholesky_factor_cov</item>
+      <item>corr_matrix</item>
+      <item>cov_matrix</item>
+      <item>void</item>
+    </list>
+    <contexts>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Normal">
+        <DetectSpaces />
+        <DetectChar attribute="Comment" context="Hash comment" char="#"/>
+        <Detect2Chars attribute="Comment" context="C-style comment" char="/" char1="/"/>
+        <Detect2Chars attribute="Comment" context="Block comment" char="/" char1="*" beginRegion="Comment"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\btarget\s*\+=" />
+        <DetectChar attribute="Operator" context="After less-than" char="&lt;" />
+        <DetectChar attribute="Punctuation" context="After comma" char="," />
+        <DetectChar attribute="Operator" context="After Right Paren" char=")" />
+        <RegExpr attribute="Keyword" context="#stay" String="\b(functions|(transformed\s+)?(data|parameters)|model|generated\s+quantities)\b" />
+        <keyword attribute="Control Flow" context="#stay" String="controlflow" />
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <keyword attribute="Data Type" context="#stay" String="types" />
+        <RegExpr attribute="Identifier" context="#stay" String="[A-Za-z][A-Za-z0-9_]*" />
+        <Float attribute="Real" />
+        <Int attribute="Int" />
+        <DetectChar attribute="Punctuation" context="#stay" char="{" beginRegion="Brace1" />
+        <DetectChar attribute="Punctuation" context="#stay" char="}" endRegion="Brace1" />
+        <DetectChar attribute="String" context="String" char="&quot;" />
+        <RegExpr attribute="Assignment" context="#stay" String="([+-]?=|\.?[*/]=)" />
+        <RegExpr attribute="Operator" context="#stay" String="(:|\?|\|\||&amp;&amp;|==|!=|&lt;=?|&gt;=?|\+|-|\.?\*|\.?/|%|\\|'|^)" />
+        <RegExpr attribute="Punctuation" context="#stay" String="[[\]()]" />
+      </context>
+      <context attribute="String" lineEndContext="#stay" name="String">
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="Hash comment">
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="C-style comment">
+      </context>
+      <context attribute="Comment" lineEndContext="#stay" name="Block comment">
+        <RegExpr attribute="Doc Tag" String="@(return|param)\b" context="#stay" />
+        <Detect2Chars attribute="Comment" context="#pop" char="*" char1="/" endRegion="Comment"/>
+      </context>
+      <context attribute="Normal Text" name="After comma" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Upper Bound" String="upper\s*=" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="After less-than" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Upper Bound" String="upper\s*=" lookAhead="true" />
+        <RegExpr context="Lower Bound" String="lower\s*=" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="After Right Paren" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Truncation" String="T\s*\[" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="Upper Bound" lineEndContext="#stay" >
+        <RegExpr attribute="Keyword" String="upper" context="#stay" />
+        <DetectChar attribute="Punctuation" char="=" context="#pop" />
+      </context>
+      <context attribute="Normal Text" name="Lower Bound" lineEndContext="#stay" >
+        <RegExpr attribute="Keyword" String="lower" context="#stay" />
+        <DetectChar attribute="Punctuation" char="=" context="#pop" />
+      </context>
+      <context attribute="Normal Text" name="Truncation" lineEndContext="#stay" >
+        <DetectChar attribute="Keyword" char="T" context="#stay" />
+        <DetectChar attribute="Punctuation" char="[" context="#pop" />
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal Text"  defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Control Flow" defStyleNum="dsControlFlow" spellChecking="false"/>
+      <itemData name="Keyword"      defStyleNum="dsKeyword" spellChecking="false"/>
+      <itemData name="Data Type"    defStyleNum="dsDataType" spellChecking="false"/>
+      <itemData name="Int"          defStyleNum="dsDecVal" spellChecking="false"/>
+      <itemData name="Real"         defStyleNum="dsFloat" spellChecking="false"/>
+      <itemData name="String"       defStyleNum="dsString"/>
+      <itemData name="Comment"      defStyleNum="dsComment"/>
+      <itemData name="Assignment"   defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Operator"     defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Punctuation"  defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Identifier"   defStyleNum="dsNormal" spellChecking="false" />
+      <itemData name="Doc Tag"      defStyleNum="dsAnnotation" spellChecking="false" />
+    </itemDatas>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="//" />
+      <comment name="multiLine" start="/*" end="*/" />
+    </comments>
+    <keywords casesensitive="1" />
+  </general>
+</language>


### PR DESCRIPTION
Adds support for the [Stan](http://mc-stan.org/) probabilistic programming language. This commit includes the XML for the syntax, an example file, and outputs for the syntax highlighting, HTML, and folding tests.