### PR TITLE
Add BrightScript syntax

### DIFF
--- a/autotests/html/brightscript.brs.html
+++ b/autotests/html/brightscript.brs.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>brightscript.brs</title>
+<meta name="generator" content="KF5::SyntaxHighlighting (BrightScript)"/>
+</head><body style="color:#1f1c1b"><pre>
+
+<span style="color:#006e28;">#i am macro</span>
+
+<span style="color:#ff5500;">library </span><span style="color:#bf0303;">&quot;a&quot;</span>
+
+<span style="font-weight:bold;">function</span> <span style="color:#644a9b;">myfunc</span> ( <span style="color:#0057ae;">foo</span> <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Integer</span> , <span style="color:#0057ae;">bar</span> <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Float</span> = <span style="color:#b08000;">3.5</span> ) <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Void</span>
+<span style="font-weight:bold;">end function</span>
+
+<span style="font-weight:bold;">sub</span> <span style="color:#644a9b;">mysub</span> ( <span style="color:#0057ae;">foo</span> <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Integer</span> , <span style="color:#0057ae;">bar</span> <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Float</span> = <span style="color:#b08000;">3.5</span> ) <span style="font-weight:bold;">as</span> <span style="color:#0057ae;">Void</span>
+<span style="font-weight:bold;">end sub</span>
+
+<span style="color:#898887;">' my comment</span>
+
+<span style="font-weight:bold;">Function</span> <span style="color:#644a9b;">MyCamelCaseFunction</span>()
+    <span style="color:#0057ae;">lvalue</span> = <span style="color:#0057ae;">rvalue</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#b08000;">5</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#b08000;">5!</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#b08000;">5#</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#b08000;">5%</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#b08000;">5&amp;</span>
+
+<span style="color:#0057ae;">a$</span>=<span style="color:#b08000;">5</span>
+<span style="color:#0057ae;">a!</span>=<span style="color:#b08000;">5</span>
+<span style="color:#0057ae;">a#</span>=<span style="color:#b08000;">5</span>
+<span style="color:#0057ae;">a%</span>=<span style="color:#b08000;">5</span>
+<span style="color:#0057ae;">a&amp;</span>=<span style="color:#b08000;">5</span>
+
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a$</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a!</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a#</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a%</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a&amp;</span>
+
+<span style="color:#644a9b;">foo</span>()
+<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">foo</span>()
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">foo</span>()
+
+<span style="color:#bf0303;text-decoration:underline;">eval</span>=5
+<span style="color:#644a9b;font-weight:bold;">eval</span>()
+<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">eval</span>()
+
+<span style="color:#0057ae;">a</span>=<span style="color:#bf0303;text-decoration:underline;">eval</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#644a9b;font-weight:bold;">eval</span>()
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">eval</span>()
+
+<span style="color:#0057ae;">sleep</span>=<span style="color:#b08000;">5</span>
+<span style="color:#644a9b;font-weight:bold;">sleep</span>()
+<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">sleep</span>()
+
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">sleep</span>
+<span style="color:#0057ae;">a</span>=<span style="color:#644a9b;font-weight:bold;">sleep</span>()
+<span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">sleep</span>()
+
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span>=<span style="color:#0057ae;">b</span> <span style="color:#0057ae;">c</span>=<span style="color:#0057ae;">d</span>
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span> <span style="color:#644a9b;">foo</span>()
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span> <span style="font-weight:bold;">then</span> <span style="color:#644a9b;">foo</span>()
+
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span>
+<span style="font-weight:bold;">end if</span>
+
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span> <span style="font-weight:bold;">then</span>
+<span style="font-weight:bold;">end if</span>
+
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span>
+<span style="font-weight:bold;">else</span> <span style="font-weight:bold;">if</span>
+<span style="font-weight:bold;">else</span>
+<span style="font-weight:bold;">end if</span>
+
+<span style="font-weight:bold;">if</span> <span style="color:#0057ae;">a</span>
+<span style="font-weight:bold;">elseif</span>
+<span style="font-weight:bold;">endif</span>
+
+<span style="font-weight:bold;">for</span> <span style="font-weight:bold;">each</span> <span style="color:#0057ae;">a</span> <span style="font-weight:bold;">in</span> <span style="color:#0057ae;">b</span>
+<span style="font-weight:bold;">end for</span>
+
+<span style="font-weight:bold;">for</span> <span style="color:#0057ae;">a</span>=<span style="color:#b08000;">1</span> <span style="font-weight:bold;">to</span> <span style="color:#b08000;">10</span> <span style="font-weight:bold;">step</span> <span style="color:#b08000;">2</span>
+<span style="font-weight:bold;">endFor</span>
+
+<span style="font-weight:bold;">for</span> <span style="font-weight:bold;">each</span> <span style="color:#0057ae;">a</span> <span style="font-weight:bold;">in</span> <span style="color:#0057ae;">b</span>
+<span style="font-weight:bold;">next</span>
+
+<span style="font-weight:bold;">while</span> <span style="color:#0057ae;">a</span>
+<span style="font-weight:bold;">end while</span>
+
+<span style="font-weight:bold;">while</span> <span style="color:#0057ae;">a</span>
+<span style="font-weight:bold;">endWhile</span>
+
+<span style="color:#0057ae;">a</span> [ <span style="color:#bf0303;">&quot;a&quot;</span> , <span style="color:#b08000;">1</span>, <span style="color:#644a9b;">foo</span>() ] = <span style="color:#b08000;">1</span>
+<span style="color:#0057ae;">a</span>.<span style="color:#644a9b;">foo</span>()[<span style="color:#b08000;">1</span>]=<span style="color:#b08000;">1</span>
+
+<span style="color:#0057ae;">a</span> = {
+    <span style="color:#0057ae;">a</span> : <span style="color:#b08000;">1</span>
+    <span style="color:#0057ae;">b</span> : <span style="color:#bf0303;">&quot;2&quot;</span>
+    <span style="color:#0057ae;">c</span> : <span style="font-weight:bold;">function</span>() <span style="color:#3daee9;">:</span> <span style="font-weight:bold;">end function</span>
+}
+
+<span style="color:#0057ae;">b</span>.<span style="color:#644a9b;">foo</span>(<span style="color:#bf0303;">&quot;string&quot;</span>,<span style="color:#b08000;">1</span>,{<span style="color:#0057ae;">a</span>:<span style="color:#0057ae;">b</span>},<span style="color:#b08000;">1.5</span>,[<span style="color:#b08000;">1</span>,<span style="color:#b08000;">2</span>,<span style="color:#b08000;">3</span>])
+<span style="color:#0057ae;">a</span> = <span style="color:#0057ae;">b</span>.<span style="color:#644a9b;">foo</span>(<span style="color:#bf0303;">&quot;string&quot;</span>,<span style="color:#b08000;">1</span>,{<span style="color:#0057ae;">a</span>:<span style="color:#0057ae;">b</span>},<span style="color:#b08000;">1.5</span>,[<span style="color:#b08000;">1</span>,<span style="color:#b08000;">2</span>,<span style="color:#b08000;">3</span>])
+<span style="font-weight:bold;">endFunction</span>
+</pre></body></html>

--- a/autotests/input/brightscript.brs
+++ b/autotests/input/brightscript.brs
@@ -1,0 +1,99 @@
+
+#i am macro
+
+library "a"
+
+function myfunc ( foo as Integer , bar as Float = 3.5 ) as Void
+end function
+
+sub mysub ( foo as Integer , bar as Float = 3.5 ) as Void
+end sub
+
+' my comment
+
+Function MyCamelCaseFunction()
+    lvalue = rvalue
+a=5
+a=5!
+a=5#
+a=5%
+a=5&
+
+a$=5
+a!=5
+a#=5
+a%=5
+a&=5
+
+a=a$
+a=a!
+a=a#
+a=a%
+a=a&
+
+foo()
+a.foo()
+a=a.foo()
+
+eval=5
+eval()
+a.eval()
+
+a=eval
+a=eval()
+a=a.eval()
+
+sleep=5
+sleep()
+a.sleep()
+
+a=sleep
+a=sleep()
+a=a.sleep()
+
+if a=b c=d
+if a foo()
+if a then foo()
+
+if a
+end if
+
+if a then
+end if
+
+if a
+else if
+else
+end if
+
+if a
+elseif
+endif
+
+for each a in b
+end for
+
+for a=1 to 10 step 2
+endFor
+
+for each a in b
+next
+
+while a
+end while
+
+while a
+endWhile
+
+a [ "a" , 1, foo() ] = 1
+a.foo()[1]=1
+
+a = {
+    a : 1
+    b : "2"
+    c : function() : end function
+}
+
+b.foo("string",1,{a:b},1.5,[1,2,3])
+a = b.foo("string",1,{a:b},1.5,[1,2,3])
+endFunction

--- a/autotests/input/brightscript.brs.syntax
+++ b/autotests/input/brightscript.brs.syntax
@@ -1,0 +1,1 @@
+BrightScript

--- a/autotests/reference/brightscript.brs.ref
+++ b/autotests/reference/brightscript.brs.ref
@@ -1,0 +1,99 @@
+<dsNormal></dsNormal><br/>
+<macro>#i am macro</macro><br/>
+<dsNormal></dsNormal><br/>
+<import>library </import><string>"a"</string><br/>
+<dsNormal></dsNormal><br/>
+<keyword>function</keyword><g> </g><func>myfunc</func><g> </g><scope>(</scope><g> </g><var>foo</var><g> </g><keyword>as</keyword><g> </g><type>Integer</type><g> </g><coma>,</coma><g> </g><var>bar</var><g> </g><keyword>as</keyword><g> </g><type>Float</type><g> </g><assign>=</assign><g> </g><float>3.5</float><g> </g><scope>)</scope><g> </g><keyword>as</keyword><g> </g><type>Void</type><br/>
+<keyword>end function</keyword><br/>
+<dsNormal></dsNormal><br/>
+<keyword>sub</keyword><g> </g><func>mysub</func><g> </g><scope>(</scope><g> </g><var>foo</var><g> </g><keyword>as</keyword><g> </g><type>Integer</type><g> </g><coma>,</coma><g> </g><var>bar</var><g> </g><keyword>as</keyword><g> </g><type>Float</type><g> </g><assign>=</assign><g> </g><float>3.5</float><g> </g><scope>)</scope><g> </g><keyword>as</keyword><g> </g><type>Void</type><br/>
+<keyword>end sub</keyword><br/>
+<dsNormal></dsNormal><br/>
+<comment>' my comment</comment><br/>
+<dsNormal></dsNormal><br/>
+<keyword>Function</keyword><g> </g><func>MyCamelCaseFunction</func><scope>()</scope><br/>
+<g>    </g><var>lvalue</var><g> </g><assign>=</assign><g> </g><var>rvalue</var><br/>
+<var>a</var><assign>=</assign><dec>5</dec><br/>
+<var>a</var><assign>=</assign><float>5!</float><br/>
+<var>a</var><assign>=</assign><float>5#</float><br/>
+<var>a</var><assign>=</assign><dec>5%</dec><br/>
+<var>a</var><assign>=</assign><dec>5&</dec><br/>
+<dsNormal></dsNormal><br/>
+<var>a$</var><assign>=</assign><dec>5</dec><br/>
+<var>a!</var><assign>=</assign><dec>5</dec><br/>
+<var>a#</var><assign>=</assign><dec>5</dec><br/>
+<var>a%</var><assign>=</assign><dec>5</dec><br/>
+<var>a&</var><assign>=</assign><dec>5</dec><br/>
+<dsNormal></dsNormal><br/>
+<var>a</var><assign>=</assign><var>a$</var><br/>
+<var>a</var><assign>=</assign><var>a!</var><br/>
+<var>a</var><assign>=</assign><var>a#</var><br/>
+<var>a</var><assign>=</assign><var>a%</var><br/>
+<var>a</var><assign>=</assign><var>a&</var><br/>
+<dsNormal></dsNormal><br/>
+<func>foo</func><scope>()</scope><br/>
+<var>a</var><operator>.</operator><func>foo</func><scope>()</scope><br/>
+<var>a</var><assign>=</assign><var>a</var><operator>.</operator><func>foo</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<invalid>eval</invalid><g>=5</g><br/>
+<builtin_func>eval</builtin_func><scope>()</scope><br/>
+<var>a</var><operator>.</operator><func>eval</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<var>a</var><assign>=</assign><invalid>eval</invalid><br/>
+<var>a</var><assign>=</assign><builtin_func>eval</builtin_func><scope>()</scope><br/>
+<var>a</var><assign>=</assign><var>a</var><operator>.</operator><func>eval</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<var>sleep</var><assign>=</assign><dec>5</dec><br/>
+<library_func>sleep</library_func><scope>()</scope><br/>
+<var>a</var><operator>.</operator><func>sleep</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<var>a</var><assign>=</assign><var>sleep</var><br/>
+<var>a</var><assign>=</assign><library_func>sleep</library_func><scope>()</scope><br/>
+<var>a</var><assign>=</assign><var>a</var><operator>.</operator><func>sleep</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<control>if</control><g> </g><var>a</var><binary>=</binary><var>b</var><g> </g><var>c</var><assign>=</assign><var>d</var><br/>
+<control>if</control><g> </g><var>a</var><g> </g><func>foo</func><scope>()</scope><br/>
+<control>if</control><g> </g><var>a</var><g> </g><control>then</control><g> </g><func>foo</func><scope>()</scope><br/>
+<dsNormal></dsNormal><br/>
+<control>if</control><g> </g><var>a</var><br/>
+<control>end if</control><br/>
+<dsNormal></dsNormal><br/>
+<control>if</control><g> </g><var>a</var><g> </g><control>then</control><br/>
+<control>end if</control><br/>
+<dsNormal></dsNormal><br/>
+<control>if</control><g> </g><var>a</var><br/>
+<control>else</control><g> </g><control>if</control><br/>
+<control>else</control><br/>
+<control>end if</control><br/>
+<dsNormal></dsNormal><br/>
+<control>if</control><g> </g><var>a</var><br/>
+<control>elseif</control><br/>
+<control>endif</control><br/>
+<dsNormal></dsNormal><br/>
+<control>for</control><g> </g><control>each</control><g> </g><var>a</var><g> </g><control>in</control><g> </g><var>b</var><br/>
+<control>end for</control><br/>
+<dsNormal></dsNormal><br/>
+<control>for</control><g> </g><var>a</var><assign>=</assign><dec>1</dec><g> </g><control>to</control><g> </g><dec>10</dec><g> </g><control>step</control><g> </g><dec>2</dec><br/>
+<control>endFor</control><br/>
+<dsNormal></dsNormal><br/>
+<control>for</control><g> </g><control>each</control><g> </g><var>a</var><g> </g><control>in</control><g> </g><var>b</var><br/>
+<control>next</control><br/>
+<dsNormal></dsNormal><br/>
+<control>while</control><g> </g><var>a</var><br/>
+<control>end while</control><br/>
+<dsNormal></dsNormal><br/>
+<control>while</control><g> </g><var>a</var><br/>
+<control>endWhile</control><br/>
+<dsNormal></dsNormal><br/>
+<var>a</var><g> </g><operator>[</operator><g> </g><string>"a"</string><g> </g><coma>,</coma><g> </g><dec>1</dec><coma>,</coma><g> </g><func>foo</func><scope>()</scope><g> </g><operator>]</operator><g> </g><assign>=</assign><g> </g><dec>1</dec><br/>
+<var>a</var><operator>.</operator><func>foo</func><scope>()</scope><operator>[</operator><dec>1</dec><operator>]</operator><assign>=</assign><dec>1</dec><br/>
+<dsNormal></dsNormal><br/>
+<var>a</var><g> </g><assign>=</assign><g> </g><operator>{</operator><br/>
+<g>    </g><var>a</var><g> </g><operator>:</operator><g> </g><dec>1</dec><br/>
+<g>    </g><var>b</var><g> </g><operator>:</operator><g> </g><string>"2"</string><br/>
+<g>    </g><var>c</var><g> </g><operator>:</operator><g> </g><keyword>function</keyword><scope>()</scope><g> </g><line_break>:</line_break><g> </g><keyword>end function</keyword><br/>
+<operator>}</operator><br/>
+<dsNormal></dsNormal><br/>
+<var>b</var><operator>.</operator><func>foo</func><scope>(</scope><string>"string"</string><coma>,</coma><dec>1</dec><coma>,</coma><operator>{</operator><var>a</var><operator>:</operator><var>b</var><operator>}</operator><coma>,</coma><float>1.5</float><coma>,</coma><operator>[</operator><dec>1</dec><coma>,</coma><dec>2</dec><coma>,</coma><dec>3</dec><operator>]</operator><scope>)</scope><br/>
+<var>a</var><g> </g><assign>=</assign><g> </g><var>b</var><operator>.</operator><func>foo</func><scope>(</scope><string>"string"</string><coma>,</coma><dec>1</dec><coma>,</coma><operator>{</operator><var>a</var><operator>:</operator><var>b</var><operator>}</operator><coma>,</coma><float>1.5</float><coma>,</coma><operator>[</operator><dec>1</dec><coma>,</coma><dec>2</dec><coma>,</coma><dec>3</dec><operator>]</operator><scope>)</scope><br/>
+<keyword>endFunction</keyword><br/>

--- a/data/syntax/brightscript.xml
+++ b/data/syntax/brightscript.xml
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<language
+	name="BrightScript"
+	section="Scripts"
+	extensions="*.brs"
+	version="0"
+	kateversion="5.0"
+	author="Daniel Levin (dendy.ua@gmail.com)"
+	license="WTFPL">
+
+<highlighting>
+
+
+
+
+<list name="library"><item>library</item></list>
+
+<list name="function"><item>function</item></list>
+<list name="endfunction"><item>endfunction</item></list>
+<list name="sub"><item>sub</item></list>
+<list name="endsub"><item>endsub</item></list>
+<list name="as"><item>as</item></list>
+
+<list name="end"><item>end</item></list>
+<list name="exit"><item>exit</item></list>
+
+<list name="if"><item>if</item></list>
+<list name="endif"><item>endif</item></list>
+<list name="then"><item>then</item></list>
+<list name="else"><item>else</item></list>
+<list name="elseif"><item>elseif</item></list>
+
+<list name="while"><item>while</item></list>
+<list name="endwhile"><item>endwhile</item></list>
+<list name="exitwhile"><item>exitwhile</item></list>
+
+<list name="for"><item>for</item></list>
+<list name="endfor"><item>endfor</item></list>
+<list name="each"><item>each</item></list>
+<list name="in"><item>in</item></list>
+<list name="to"><item>to</item></list>
+<list name="step"><item>step</item></list>
+<list name="next"><item>next</item></list>
+
+<list name="print"><item>print</item></list>
+<list name="return"><item>return</item></list>
+
+<list name="dim"><item>dim</item></list>
+<list name="stop"><item>stop</item></list>
+<list name="goto"><item>goto</item></list>
+
+<list name="m"><item>m</item></list>
+<list name="top">
+	<item>top</item>
+	<item>global</item>
+</list>
+
+<list name="end_of_scope">
+	<item>then</item>
+	<item>end</item>
+	<item>exit</item>
+</list>
+
+<list name="unary">
+	<item>not</item>
+</list>
+
+<list name="builtin_functions">
+	<item>tab</item>
+	<item>pos</item>
+	<item>CreateObject</item>
+	<item>Type</item>
+	<item>GetGlobalAA</item>
+	<item>Box</item>
+	<item>Run</item>
+	<item>Eval</item>
+	<item>GetLastRunCompileError</item>
+	<item>GetLastRunRuntimeError</item>
+	<item>ObjFun</item>
+</list>
+
+<list name="utility_functions">
+	<item>Sleep</item>
+	<item>Wait</item>
+	<item>GetInterface</item>
+	<item>FindMemberFunction</item>
+	<item>UpTime</item>
+	<item>RebootSystem</item>
+	<item>ListDir</item>
+	<item>ReadAsciiFile</item>
+	<item>WriteAsciiFile</item>
+	<item>CopyFile</item>
+	<item>MoveFile</item>
+	<item>MatchFiles</item>
+	<item>DeleteFile</item>
+	<item>DeleteDirectory</item>
+	<item>CreateDirectory</item>
+	<item>FormatDrive</item>
+	<item>StrToI</item>
+	<item>RunGarbageCollector</item>
+	<item>ParseJson</item>
+	<item>FormatJson</item>
+	<item>Tr</item>
+</list>
+
+<list name="string_functions">
+	<item>UCase</item>
+	<item>LCase</item>
+	<item>Asc</item>
+	<item>Chr</item>
+	<item>Instr</item>
+	<item>Left</item>
+	<item>Len</item>
+	<item>Mid</item>
+	<item>Str</item>
+	<item>StrI</item>
+	<item>String</item>
+	<item>StringI</item>
+	<item>Val</item>
+	<item>Substitute</item>
+</list>
+
+<list name="math_functions">
+	<item>Abs</item>
+	<item>Atn</item>
+	<item>Cdbl</item>
+	<item>Cint</item>
+	<item>Cos</item>
+	<item>Csng</item>
+	<item>Exp</item>
+	<item>Fix</item>
+	<item>Int</item>
+	<item>Log</item>
+	<item>Rnd</item>
+	<item>Sgn</item>
+	<item>Sin</item>
+	<item>Sqr</item>
+	<item>Tan</item>
+</list>
+
+<list name="comments">
+	<item>rem</item>
+</list>
+
+<list name="types">
+	<item>invalid</item>
+	<item>void</item>
+	<item>dynamic</item>
+	<item>boolean</item>
+	<item>integer</item>
+	<item>longinteger</item>
+	<item>float</item>
+	<item>double</item>
+	<item>string</item>
+	<item>object</item>
+	<item>function</item>
+	<item>interface</item>
+</list>
+
+<list name="constants">
+	<item>true</item>
+	<item>false</item>
+	<item>invalid</item>
+	<item>LINE_NUM</item>
+</list>
+
+
+
+
+<contexts>
+
+<!-- Contexts starting with @ are for inclusion only. -->
+
+<context name="global" attribute="g" lineEndContext="#stay">
+	<DetectSpaces/>
+	<keyword String="library" attribute="import" context="library"/>
+	<IncludeRules context="@comment"/>
+	<IncludeRules context="@macro"/>
+	<IncludeRules context="@function"/>
+	<IncludeRules context="@sub"/>
+</context>
+
+
+<!-- Import statement, which might appear at the global context:
+         library "mylibname.brs"
+-->
+<context name="library" attribute="import" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectChar char="&quot;" attribute="string" context="#pop!string"/>
+</context>
+
+
+<!-- Comments have higher priority over anything else. -->
+<context name="@comment" attribute="g" lineEndContext="#stay">
+	<DetectSpaces/>
+	<DetectChar char="'" attribute="comment" context="comment"/>
+	<keyword String="comments" attribute="comment" context="comment"/>
+</context>
+
+<context name="comment" attribute="comment" lineEndContext="#pop">
+</context>
+
+
+<!-- Macro statement starts with # and might appear anywhere in the code:
+         #if foo
+             ...
+         #else
+             ...
+         #endif
+-->
+<context name="@macro" attribute="g" lineEndContext="#stay">
+	<DetectChar char="#" attribute="macro" context="macro_line"/>
+</context>
+
+<context name="macro_line" attribute="macro" lineEndContext="#pop">
+	<IncludeRules context="@comment"/>
+</context>
+
+
+<!-- Colon starts a new line. -->
+<context name="line_break" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@line_break"/>
+</context>
+
+<context name="@line_break" attribute="g" lineEndContext="#stay">
+	<DetectChar char=":" attribute="line_break" context="#pop"/>
+</context>
+
+
+<!-- Common rules for function and sub. -->
+<context name="@code_end" attribute="g" lineEndContext="#stay">
+	<RegExpr String="end\s+(if|for|while)" insensitive="true" attribute="control" context="#pop"/>
+</context>
+
+<context name="arg_as_type" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="var" context="#pop!arg_params"/>
+</context>
+
+<context name="arg_params" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<keyword String="as" context="as_type" lookAhead="true"/>
+	<DetectChar char="=" attribute="assign" context="rvalue"/>
+</context>
+
+<context name="as_type" attribute="g" lineEndContext="#stay">
+	<keyword String="as" attribute="keyword" context="as_type_value"/>
+</context>
+
+<context name="as_type_value" attribute="g" lineEndContext="#stay">
+	<keyword String="types" attribute="type" context="#pop#pop"/>
+	<DetectIdentifier attribute="invalid" context="#pop#pop"/>
+</context>
+
+
+<!-- Regular function definition. -->
+<context name="@function" attribute="g" lineEndContext="#stay">
+	<keyword String="function" attribute="keyword" context="function"/>
+</context>
+
+<context name="function" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="function_name">
+</context>
+
+<context name="function_name" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!function_code">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="func" context="#pop!func_open_brace"/>
+	<DetectChar char="(" context="#pop!func_open_brace" lookAhead="true"/>
+</context>
+
+<context name="func_open_brace" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!function_code">
+	<DetectSpaces/>
+	<DetectChar char="(" attribute="scope" context="func_args"/>
+</context>
+
+<context name="func_args" attribute="g" lineEndContext="#stay" fallthroughContext="#pop#pop!function_code">
+	<DetectSpaces/>
+	<DetectIdentifier context="arg_as_type" lookAhead="true"/>
+	<DetectChar char=")" attribute="scope" context="#pop#pop!function_ret"/>
+	<DetectChar char="," attribute="coma" context="arg_as_type"/>
+</context>
+
+<context name="function_ret" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!function_code">
+	<DetectChar char=" " context="#stay"/>
+	<keyword String="as" context="as_type" lookAhead="true"/>
+</context>
+
+<context name="function_code" attribute="g" lineEndContext="#stay">
+	<DetectSpaces/>
+	<keyword String="end" context="function_end" lookAhead="true"/>
+	<keyword String="endfunction" attribute="keyword" context="#pop#pop"/>
+	<IncludeRules context="@code"/>
+</context>
+
+<context name="function_end" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<RegExpr String="end\s+function" insensitive="true" attribute="keyword" context="#pop#pop#pop"/>
+	<IncludeRules context="@code_end"/>
+</context>
+
+
+<!-- sub is a function with void return type. -->
+<context name="@sub" attribute="g" lineEndContext="#stay">
+	<keyword String="sub" attribute="keyword" context="sub"/>
+</context>
+
+<context name="sub" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="sub_name">
+</context>
+
+<context name="sub_name" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!sub_code">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="func" context="#pop!sub_open_brace"/>
+</context>
+
+<context name="sub_open_brace" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!sub_code">
+	<DetectSpaces/>
+	<DetectChar char="(" attribute="scope" context="sub_args"/>
+</context>
+
+<context name="sub_args" attribute="g" lineEndContext="#stay" fallthroughContext="#pop#pop!sub_code">
+	<DetectSpaces/>
+	<DetectIdentifier context="arg_as_type" lookAhead="true"/>
+	<DetectChar char=")" attribute="scope" context="#pop#pop!sub_ret"/>
+	<DetectChar char="," attribute="coma" context="arg_as_type"/>
+</context>
+
+<context name="sub_ret" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop!sub_code">
+	<DetectChar char=" " context="#stay"/>
+	<keyword String="as" context="as_type" lookAhead="true"/>
+</context>
+
+<context name="sub_code" attribute="code" lineEndContext="#stay">
+	<DetectSpaces/>
+	<keyword String="end" context="sub_end" lookAhead="true"/>
+	<keyword String="endsub" attribute="keyword" context="#pop#pop"/>
+	<IncludeRules context="@code"/>
+</context>
+
+<context name="sub_end" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop#pop">
+	<DetectSpaces/>
+	<RegExpr String="end\s+sub" insensitive="true" attribute="keyword" context="#pop#pop#pop"/>
+	<IncludeRules context="@code_end"/>
+</context>
+
+
+<!-- @code represents execution body, including function and sub contents.
+-->
+<context name="@code" attribute="g" lineEndContext="#stay">
+	<DetectSpaces/>
+	<IncludeRules context="@macro"/>
+	<IncludeRules context="@comment"/>
+
+	<keyword String="print" attribute="print" context="print"/>
+	<keyword String="goto" attribute="keyword" context="goto"/>
+	<keyword String="return" attribute="control" context="rvalue"/>
+	<keyword String="stop" attribute="keyword"/>
+
+	<keyword String="dim" attribute="keyword" context="dim"/>
+
+	<keyword String="if" attribute="control" context="rvalue"/>
+	<keyword String="then" attribute="control"/>
+	<keyword String="else" attribute="control"/>
+	<keyword String="elseif" attribute="control"/>
+	<keyword String="endif" attribute="control"/>
+
+	<keyword String="while" attribute="control" context="rvalue"/>
+	<keyword String="endwhile" attribute="control"/>
+	<keyword String="exitwhile" attribute="control"/>
+
+	<keyword String="for" attribute="control" context="for"/>
+	<keyword String="endfor" attribute="control"/>
+	<keyword String="next" attribute="control"/>
+
+	<keyword String="exit" attribute="control" context="exit"/>
+
+	<DetectChar char=":" context="line_break" lookAhead="true"/>
+
+	<DetectIdentifier context="lvalue" lookAhead="true"/>
+</context>
+
+<context name="print" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="rvalue">
+	<DetectChar char="," attribute="coma"/>
+	<DetectChar char=";" attribute="coma"/>
+	<IncludeRules context="@line_break"/>
+</context>
+
+<context name="goto" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="label" context="#pop"/>
+</context>
+
+<context name="dim" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="var" context="#pop!dim_array"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="dim_array" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectChar char="[" attribute="operator" context="#pop!array"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="for" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!for_var">
+	<DetectSpaces/>
+	<keyword String="each" attribute="control" context="#pop!for_each"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="for_each" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectIdentifier attribute="var" context="#pop!for_in"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="for_in" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<keyword String="in" attribute="control" context="#pop!rvalue"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="for_var" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="lvalue">
+	<DetectSpaces/>
+	<keyword String="to" attribute="control" context="#pop!for_to"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="for_to" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<keyword String="step" attribute="control" context="#pop!rvalue"/>
+</context>
+
+<context name="exit" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<keyword String="for" attribute="control" context="#pop"/>
+	<keyword String="while" attribute="control" context="#pop"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+
+
+<!-- Builtin functions are reserved keywords. They cannot be used as a local variable names.
+     Thus doing something like below is an error and will be highlighted with 'invalid':
+         eval = 1
+         foo = eval
+     It is still valid to use any word, including reserved ones, as an variable parameter:
+         foo.eval = 1
+         foo = bar.eval
+         foo.eval()
+-->
+<context name="@lvalue_builtin_functions" attribute="g" lineEndContext="#stay">
+    <keyword String="builtin_functions" context="#pop!lvalue_builtin_function" lookAhead="true"/>
+</context>
+
+<context name="lvalue_builtin_function" attribute="g" lineEndContext="#pop">
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!lvalue_builtin_call" lookAhead="true"/>
+	<DetectIdentifier attribute="invalid" context="#pop"/>
+</context>
+
+<context name="lvalue_builtin_call" attribute="g" lineEndContext="#pop">
+	<DetectIdentifier attribute="builtin_func" context="#pop!lvalue_call_open_brace"/>
+</context>
+
+
+<context name="@rvalue_builtin_functions" attribute="g" lineEndContext="#stay">
+    <keyword String="builtin_functions" context="#pop!rvalue_builtin_function" lookAhead="true"/>
+</context>
+
+<context name="rvalue_builtin_function" attribute="g" lineEndContext="#pop">
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!rvalue_builtin_call" lookAhead="true"/>
+	<DetectIdentifier attribute="invalid" context="#pop"/>
+</context>
+
+<context name="rvalue_builtin_call" attribute="g" lineEndContext="#pop">
+	<DetectIdentifier attribute="builtin_func" context="#pop!rvalue_call_open_brace"/>
+</context>
+
+
+<!-- Library functions have nothing special comparing to other functions. They just have different
+     highlighting colors. It is valid to shadow function with a variable with the same name,
+     although it is not recommended and might be considered as a warning by various linters.
+-->
+<context name="@lvalue_library_functions" attribute="g" lineEndContext="#stay">
+	<keyword String="utility_functions" context="#pop!lvalue_library_function" lookAhead="true"/>
+	<keyword String="string_functions" context="#pop!lvalue_library_function" lookAhead="true"/>
+	<keyword String="math_functions" context="#pop!lvalue_library_function" lookAhead="true"/>
+</context>
+
+<context name="lvalue_library_function" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!lvalue_var">
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!lvalue_library_call" lookAhead="true"/>
+</context>
+
+<context name="lvalue_library_call" attribute="g" lineEndContext="#pop">
+	<DetectIdentifier attribute="library_func" context="#pop!lvalue_call_open_brace"/>
+</context>
+
+
+<context name="@rvalue_library_functions" attribute="g" lineEndContext="#stay">
+	<keyword String="utility_functions" context="#pop!rvalue_library_function" lookAhead="true"/>
+	<keyword String="string_functions" context="#pop!rvalue_library_function" lookAhead="true"/>
+	<keyword String="math_functions" context="#pop!rvalue_library_function" lookAhead="true"/>
+</context>
+
+<context name="rvalue_library_function" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!rvalue_var">
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!rvalue_library_call" lookAhead="true"/>
+</context>
+
+<context name="rvalue_library_call" attribute="g" lineEndContext="#pop">
+	<DetectIdentifier attribute="library_func" context="#pop!rvalue_call_open_brace"/>
+</context>
+
+
+<!-- lvalue contexts represent expressions of the left side of the assignment operators or
+	 standalone function calls.
+-->
+<context name="lvalue" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!lvalue_exp">
+	<DetectSpaces/>
+	<keyword String="m" attribute="m" context="#pop!lvalue_m_dot"/>
+	<IncludeRules context="@lvalue_builtin_functions"/>
+	<IncludeRules context="@lvalue_library_functions"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="lvalue_exp" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!lvalue_call" lookAhead="true"/>
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*:" attribute="label" context="#pop"/>
+	<DetectIdentifier context="#pop!lvalue_var" lookAhead="true"/>
+</context>
+
+<context name="lvalue_m_dot" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<DetectChar char="." attribute="operator" context="#pop!lvalue_top"/>
+	<IncludeRules context="@comment"/>
+	<IncludeRules context="@lvalue_ops"/>
+</context>
+
+<context name="lvalue_top" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<keyword String="top" attribute="top" context="#pop!lvalue_operator"/>
+	<DetectIdentifier context="#pop!lvalue_exp" lookAhead="true"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="lvalue_var" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<DetectIdentifier attribute="var" context="#pop!lvalue_var_postfix"/>
+</context>
+
+<context name="lvalue_var_postfix" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!lvalue_operator">
+	<AnyChar String="$%&amp;!#" attribute="var" context="#pop!lvalue_operator"/>
+</context>
+
+<context name="lvalue_operator" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<DetectChar char="." attribute="operator" context="#pop!lvalue_exp"/>
+	<IncludeRules context="@lvalue_ops"/>
+</context>
+
+<context name="@lvalue_ops" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@lvalue_call_open_brace"/>
+	<DetectChar char="[" attribute="operator" context="lvalue_array"/>
+	<RegExpr String="(=|\+=|\-=|\*=|/=|\\=|&lt;&lt;=|&gt;&gt;=)" attribute="assign" context="#pop!rvalue"/>
+</context>
+
+<context name="lvalue_array" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<DetectChar char="," attribute="coma"/>
+	<DetectChar char="]" attribute="operator" context="#pop!lvalue_operator"/>
+</context>
+
+<context name="lvalue_call" attribute="g" lineEndContext="#stay">
+	<DetectIdentifier attribute="func" context="#pop!lvalue_call_open_brace"/>
+</context>
+
+<context name="lvalue_call_open_brace" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@lvalue_call_open_brace"/>
+</context>
+
+<context name="@lvalue_call_open_brace" attribute="g" lineEndContext="#stay">
+	<DetectChar char="(" attribute="scope" context="lvalue_call_args"/>
+</context>
+
+<context name="lvalue_call_args" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<DetectChar char=")" attribute="scope" context="#pop#pop!lvalue_operator"/>
+	<DetectChar char="," attribute="coma"/>
+</context>
+
+
+<!-- rvalue contexts represent expressions on the right side of assignment operators and arguments
+	 to other functions, 'print' calls, object keys, array values, etc.
+-->
+<context name="rvalue" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<IncludeRules context="@comment"/>
+	<IncludeRules context="@function"/>
+	<IncludeRules context="@sub"/>
+	<keyword String="unary" attribute="unary"/>
+	<keyword String="end_of_scope" context="#pop#pop" lookAhead="true"/>
+	<DetectChar char="&quot;" attribute="string" context="#pop!string"/>
+	<DetectChar char="[" attribute="operator" context="#pop!array"/>
+	<DetectChar char="(" attribute="scope" context="#pop!rvalue_scope"/>
+	<DetectChar char="{" attribute="operator" context="#pop!object"/>
+	<keyword String="constants" attribute="constant" context="#pop!rvalue_operator"/>
+	<RegExpr String="[-+]?[0-9]*\.[0-9]" context="#pop!float" lookAhead="true"/>
+	<RegExpr String="[-+]?[0-9]" context="#pop!int" lookAhead="true"/>
+	<keyword String="m" attribute="m" context="#pop!rvalue_m_dot"/>
+	<IncludeRules context="@rvalue_builtin_functions"/>
+	<IncludeRules context="@rvalue_library_functions"/>
+	<IncludeRules context="@rvalue_dot"/>
+</context>
+
+<context name="rvalue_var" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop">
+	<DetectIdentifier attribute="var" context="#pop!rvalue_var_postfix"/>
+</context>
+
+<context name="rvalue_var_postfix" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!rvalue_operator">
+	<AnyChar String="$%&amp;!#" attribute="var" context="#pop!rvalue_operator"/>
+</context>
+
+<context name="rvalue_operator" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!rvalue_end">
+	<DetectSpaces/>
+	<DetectChar char="." attribute="operator" context="#pop!rvalue_dot"/>
+	<IncludeRules context="@rvalue_ops"/>
+</context>
+
+<context name="@rvalue_ops" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@rvalue_call_open_brace"/>
+	<DetectChar char="[" attribute="operator" context="#pop!array"/>
+</context>
+
+<context name="rvalue_end" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<DetectSpaces/>
+	<RegExpr String="(=|&lt;&gt;|&lt;&lt;|&gt;&gt;|&lt;=|&gt;=|&lt;|&gt;|\^|\-|\+|\*|\/|\\)" context="#pop!rvalue_binary" lookAhead="true"/>
+	<RegExpr String="(and|or|mod)[\W]" insensitive="true" context="#pop!rvalue_binary" lookAhead="true"/>
+</context>
+
+<context name="rvalue_binary" attribute="invalid" lineEndContext="#stay">
+	<DetectSpaces/>
+	<RegExpr String="(=|&lt;&gt;|&lt;&lt;|&gt;&gt;|&lt;=|&gt;=|&lt;|&gt;|\^|\-|\+|\*|\/|\\|and|or|mod)" insensitive="true" attribute="binary" context="#pop!rvalue"/>
+</context>
+
+<context name="rvalue_m_dot" attribute="g" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop!rvalue_end">
+	<DetectSpaces/>
+	<DetectChar char="." attribute="operator" context="#pop!rvalue_top"/>
+	<IncludeRules context="@comment"/>
+	<IncludeRules context="@rvalue_ops"/>
+</context>
+
+<context name="rvalue_top" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<keyword String="top" attribute="top" context="#pop!rvalue_operator"/>
+	<DetectIdentifier context="#pop!rvalue_dot" lookAhead="true"/>
+	<IncludeRules context="@comment"/>
+</context>
+
+<context name="rvalue_scope" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<DetectChar char=")" attribute="scope" context="#pop!rvalue_operator"/>
+</context>
+
+<context name="rvalue_dot" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@rvalue_dot"/>
+</context>
+
+<context name="@rvalue_dot" attribute="g" lineEndContext="#stay">
+	<RegExpr String="[a-zA-Z_][a-zA-Z0-1_]*\s*\(" context="#pop!rvalue_call" lookAhead="true"/>
+	<DetectIdentifier context="#pop!rvalue_var" lookAhead="true"/>
+</context>
+
+
+<!-- Other rvalue expressions. -->
+<context name="string" attribute="string" lineEndContext="#pop#pop">
+	<DetectChar char="&quot;" attribute="string" context="#pop!rvalue_operator"/>
+</context>
+
+<context name="array" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<DetectChar char="," attribute="coma"/>
+	<DetectChar char="]" attribute="operator" context="#pop!rvalue_operator"/>
+</context>
+
+<context name="object" attribute="g" lineEndContext="#stay">
+	<DetectSpaces/>
+	<IncludeRules context="@comment"/>
+	<DetectChar char="," attribute="coma"/>
+	<DetectChar char="}" attribute="operator" context="#pop!rvalue_operator"/>
+	<DetectChar char="&quot;" attribute="var" context="object_param_string"/>
+	<DetectIdentifier attribute="var" context="object_param_colon"/>
+</context>
+
+<context name="object_param_string" attribute="var" lineEndContext="#pop">
+	<DetectChar char="&quot;" attribute="var" context="#pop!object_param_colon"/>
+</context>
+
+<context name="object_param_colon" attribute="g" lineEndContext="#pop">
+	<DetectSpaces/>
+	<IncludeRules context="@comment"/>
+	<DetectChar char=":" attribute="operator" context="#pop!rvalue"/>
+</context>
+
+<context name="float" attribute="float" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<!-- documentation says this is a valid string, but implementation gives compile error -->
+	<!--<RegExpr String="[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?\$" attribute="string" context="postfix_delimiter"/>-->
+	<!--<RegExpr String="[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?[%&amp;]" attribute="dec" context="postfix_delimiter"/>-->
+	<RegExpr String="[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?[!#]?" attribute="float" context="postfix_delimiter"/>
+</context>
+
+<context name="int" attribute="dec" lineEndContext="#pop" fallthrough="true" fallthroughContext="#pop">
+	<!-- documentation says this is a valid string, but implementation gives compile error -->
+	<!--<RegExpr String="[-+]?[0-9]*\$" attribute="string" context="postfix_delimiter"/>-->
+	<RegExpr String="[-+]?[0-9]*[!#]" attribute="float" context="postfix_delimiter"/>
+	<RegExpr String="[-+]?[0-9]*[%&amp;]?" attribute="dec" context="postfix_delimiter"/>
+</context>
+
+<context name="postfix_delimiter" attribute="g" lineEndContext="#pop#pop" fallthrough="true" fallthroughContext="#pop#pop">
+	<RegExpr String="[\s\W]" context="#pop#pop!rvalue_operator" lookAhead="true"/>
+</context>
+
+<context name="rvalue_call" attribute="g" lineEndContext="#stay">
+	<DetectIdentifier attribute="func" context="#pop!rvalue_call_open_brace"/>
+</context>
+
+<context name="rvalue_call_open_brace" attribute="g" lineEndContext="#stay">
+	<IncludeRules context="@rvalue_call_open_brace"/>
+</context>
+
+<context name="@rvalue_call_open_brace" attribute="g" lineEndContext="#stay">
+	<DetectChar char="(" attribute="scope" context="rvalue_call_args"/>
+</context>
+
+<context name="rvalue_call_args" attribute="g" lineEndContext="#stay" fallthrough="true" fallthroughContext="rvalue">
+	<DetectSpaces/>
+	<DetectChar char=")" attribute="scope" context="#pop#pop!rvalue_operator"/>
+	<DetectChar char="," attribute="coma"/>
+</context>
+
+</contexts>
+
+
+
+
+<itemDatas>
+	<itemData name="g"            defStyleNum="dsNormal"/>
+	<itemData name="import"       defStyleNum="dsImport"/>
+	<itemData name="func"         defStyleNum="dsFunction"/>
+	<itemData name="keyword"      defStyleNum="dsKeyword"/>
+	<itemData name="control"      defStyleNum="dsControlFlow"/>
+	<itemData name="assign"       defStyleNum="dsOperator"/>
+	<itemData name="binary"       defStyleNum="dsOperator"/>
+	<itemData name="unary"        defStyleNum="dsOperator"/>
+	<itemData name="operator"     defStyleNum="dsOperator"/>
+	<itemData name="scope"        defStyleNum="dsOperator"/>
+	<itemData name="coma"         defStyleNum="dsOperator"/>
+	<itemData name="type"         defStyleNum="dsDataType"/>
+	<itemData name="var"          defStyleNum="dsVariable"/>
+	<itemData name="comment"      defStyleNum="dsComment"/>
+	<itemData name="print"        defStyleNum="dsBuiltIn"/>
+	<itemData name="builtin_func" defStyleNum="dsBuiltIn"/>
+	<itemData name="library_func" defStyleNum="dsBuiltIn"/>
+	<itemData name="dec"          defStyleNum="dsDecVal"/>
+	<itemData name="float"        defStyleNum="dsFloat"/>
+	<itemData name="string"       defStyleNum="dsString"/>
+	<itemData name="constant"     defStyleNum="dsConstant"/>
+	<itemData name="macro"        defStyleNum="dsPreprocessor"/>
+	<itemData name="label"        defStyleNum="dsSpecialChar"/>
+	<itemData name="line_break"   defStyleNum="dsSpecialChar"/>
+	<itemData name="m"            defStyleNum="dsExtension"/>
+	<itemData name="top"          defStyleNum="dsExtension"/>
+	<itemData name="invalid"      defStyleNum="dsError"/>
+</itemDatas>
+
+</highlighting>
+
+
+
+
+<general>
+	<comments>
+		<comment name="singleLine" start="'"/>
+	</comments>
+
+	<keywords casesensitive="0" additionalDeliminator="'"/>
+</general>
+
+</language>


### PR DESCRIPTION
Accurate implementation of BrightScript language, mostly used by Roku
channel developers and documented at Roku SDK portal:

https://sdkdocs.roku.com/display/sdkdoc/Roku+SDK+Documentation

Highlight sytax covers:

- function and sub definitions, both global and inline
- comments: ' and REM
- macros
- print statement
- library imports
- literal type narrowing with: $, %, !, #, &
- conditionals and loops with: if, for and while
- built-in and library functions
- standard Roku Scene Graph keywords: m, top, global
- array, function calls
- goto and label statements
- built-in types used in function/sub arguments and return
- constants: true, false, invalid
- distinct assignment and unary/binary ops, e.g.:
      if a = b c = d
      ' first = is a comparison, second = is an assignment
- invalid syntax detection in some cases

No folding is supported at this point.