### PR TITLE
Perl6 has been renamed to Raku

### DIFF
--- a/autotests/html/highlight.pl6.html
+++ b/autotests/html/highlight.pl6.html
@@ -2,9 +2,9 @@
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 <title>highlight.pl6</title>
-<meta name="generator" content="KF5::SyntaxHighlighting (Perl6)"/>
+<meta name="generator" content="KF5::SyntaxHighlighting (Raku)"/>
 </head><body style="color:#1f1c1b"><pre>
-<span style="font-weight:bold;">#!/usr/bin/perl6</span>
+<span style="font-weight:bold;">#!/usr/bin/raku</span>
 
 <span style="font-weight:bold;">use</span> v6;
 
@@ -225,10 +225,10 @@
 <span style="color:#607880;">=</span><span style="color:#ca60ca;">head1</span><span style="color:#0095ff;"> ac</span><span style="color:#607880;font-weight:bold;">B&lt;&lt;</span><span style="color:#607880;font-style:italic;">I&lt;a&gt;</span><span style="color:#607880;font-weight:bold;">&gt;&gt;</span><span style="color:#0095ff;">a </span><span style="color:#607880;font-weight:bold;">B&lt;c&gt;</span><span style="color:#0095ff;"> </span><span style="color:#607880;text-decoration:underline;">U&lt;d&gt;</span><span style="color:#0095ff;"> B</span><span style="color:#607880;font-weight:bold;">B&lt;a&gt;</span>
 
 <span style="color:#b08000;">C&lt;my $var = 1; say $var;&gt;</span>
-<span style="color:#607880;">Perl 6 homepage </span><span style="color:#006e28;text-decoration:underline;">L&lt;https://perl6.org&gt;</span><span style="color:#607880;"> </span><span style="color:#006e28;text-decoration:underline;">L&lt;Perl 6 homepage</span>|<span style="color:#006e28;text-decoration:underline;">https://perl6.org&gt;</span>
+<span style="color:#607880;">Raku homepage </span><span style="color:#006e28;text-decoration:underline;">L&lt;https://raku.org&gt;</span><span style="color:#607880;"> </span><span style="color:#006e28;text-decoration:underline;">L&lt;Raku homepage</span>|<span style="color:#006e28;text-decoration:underline;">https://raku.org&gt;</span>
 <span style="color:#607880;">Comments </span><span style="color:#006e28;text-decoration:underline;">L&lt;#Comments&gt;</span><span style="color:#607880;"> </span><span style="color:#006e28;text-decoration:underline;">L&lt;Comments</span>|<span style="color:#006e28;text-decoration:underline;">#Comments&gt;</span>
-<span style="color:#607880;">Perl 6 is awesome </span><span style="color:#898887;">Z&lt;Of course it is!&gt;</span>
-<span style="color:#607880;">Perl 6 is multi-paradigmatic </span><span style="color:#b08000;">N&lt;Supporting Procedural, Object Oriented, and Functional programming&gt;</span>
+<span style="color:#607880;">Raku is awesome </span><span style="color:#898887;">Z&lt;Of course it is!&gt;</span>
+<span style="color:#607880;">Raku is multi-paradigmatic </span><span style="color:#b08000;">N&lt;Supporting Procedural, Object Oriented, and Functional programming&gt;</span>
 <span style="color:#607880;">Enter your name </span><span style="color:#b08000;">K&lt;John Doe&gt;</span><span style="color:#607880;"> </span><span style="color:#924c9d;">E&lt;0xBB&gt;</span><span style="color:#607880;"> characters.</span>
 
 <span style="color:#607880;">A </span><span style="color:#006e28;">X&lt;</span><span style="color:#006e28;text-decoration:underline;">hash</span>|<span style="color:#006e28;text-decoration:underline;">hashes</span>,<span style="color:#006e28;text-decoration:underline;"> definition of</span>;<span style="color:#006e28;text-decoration:underline;"> associative arrays</span><span style="color:#006e28;">&gt;</span>

--- a/data/syntax/raku.xml
+++ b/data/syntax/raku.xml
@@ -51,7 +51,7 @@
   <!-- <!ENTITY regadverb "(?!\()\s*(?::\w+\s*)*(?=[^\w\s])"> -->
   <!ENTITY regadverb "(?!\()\s*(?=[^\w\s])">
 ]>
-<language name="Perl6" version="1" kateversion="5.53" section="Scripts" extensions="*.pl6;*.PL6;*.p6;*.pm6;*.pod6" mimetype="application/x-perl;text/x-perl" priority="5" author="Jonathan Poelen (jonathan.poelen@gmail.com)" license="MIT">
+<language name="Raku" version="1" kateversion="5.53" section="Scripts" extensions="*.pl6;*.PL6;*.p6;*.pm6;*.pod6" mimetype="application/x-perl;text/x-perl" priority="5" author="Jonathan Poelen (jonathan.poelen@gmail.com)" license="MIT">
   <highlighting>
 
     <list name="pod">


### PR DESCRIPTION
Since Perl6 has been renamed to Raku, update the respective files to match.