### PR TITLE
Add tsort entry in bash.xml

### DIFF
--- a/data/syntax/bash.xml
+++ b/data/syntax/bash.xml
@@ -423,6 +423,7 @@
       <item>tee</item>
       <item>test</item>
       <item>tr</item>
+      <item>tsort</item>
       <item>uniq</item>
       <item>unlink</item>
       <item>unzip</item>


### PR DESCRIPTION
[tsort](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tsort.html) is part of the POSIX.1 standard as of 2017, but it's been around since the late 70's. Proposing to add it to the list of recognized shell utilities.