### PR TITLE
commonlisp.xml: remove truncase symbol

### DIFF
--- a/data/syntax/commonlisp.xml
+++ b/data/syntax/commonlisp.xml
@@ -911,7 +911,6 @@
       <item>translate-pathname</item> 
       <item>tree-equal</item> 
       <item>truename</item> 
-      <item>truncase</item> 
       <item>truncate</item> 
       <item>two-way-stream</item> 
       <item>two-way-stream-input-stream</item> 


### PR DESCRIPTION
TRUNCASE does not exist in Common Lisp, and as far as I can tell, it never was part of any Lisp dialect (and if it were, that would not be relevant today). It is most likely to be a typo that was introduced a long time ago and never fixed.

For context, this was discussed in the matterhorn project:

https://github.com/matterhorn-chat/matterhorn/issues/829